### PR TITLE
test: update guanghe owner fixture

### DIFF
--- a/tests/test-d7-d8.sh
+++ b/tests/test-d7-d8.sh
@@ -72,7 +72,7 @@ import PackageDescription
 let package = Package(
     name: "Downstream",
     dependencies: [
-        .package(url: "https://github.com/tongzhenghui/guanghe.git", from: "${version}")
+        .package(url: "https://github.com/huanlongAI/guanghe.git", from: "${version}")
     ]
 )
 EOF


### PR DESCRIPTION
## Summary
- update the D-8 semver Package.swift fixture from the old personal guanghe owner to huanlongAI/guanghe.git
- preserve D-8 version-drift behavior; owner is not part of the assertion

## Verification
- bash tests/test-d7-d8.sh
- rg old guanghe owner in tests/test-d7-d8.sh
- git diff --check