### PR TITLE
Add Sentinel policy_file support

### DIFF
--- a/scripts/policy-loader.sh
+++ b/scripts/policy-loader.sh
@@ -65,6 +65,39 @@ sentinel_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null || pwd
 }
 
+sentinel_realpath() {
+  local path="$1"
+  local current target dir base depth
+
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$path"
+    return
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$path"
+    return
+  fi
+
+  current="$path"
+  depth=0
+  while [ -L "$current" ]; do
+    depth=$((depth + 1))
+    if [ "$depth" -gt 40 ]; then
+      return 1
+    fi
+    target=$(readlink "$current") || return 1
+    case "$target" in
+      /*) current="$target" ;;
+      *) current="$(dirname "$current")/$target" ;;
+    esac
+  done
+
+  dir=$(dirname "$current")
+  base=$(basename "$current")
+  (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$base")
+}
+
 sentinel_validate_policy_file() {
   local file="$1" display="${2:-$1}"
   local line line_no trimmed saw_root_key
@@ -111,7 +144,7 @@ sentinel_validate_policy_file() {
 
 sentinel_policy_file_for_config() {
   local config_file="$1"
-  local policy_ref policy_path repo_root
+  local policy_ref policy_path repo_root repo_root_real policy_path_real
 
   policy_ref=$(sentinel_yaml_get "$config_file" "policy_file" "")
   if [ -z "$policy_ref" ]; then
@@ -135,6 +168,10 @@ sentinel_policy_file_for_config() {
   esac
 
   repo_root=$(sentinel_repo_root)
+  repo_root_real=$(sentinel_realpath "$repo_root") || {
+    echo "::error::Unable to resolve repository root: ${repo_root}" >&2
+    return 1
+  }
   policy_path="${repo_root}/${policy_ref}"
 
   if [ ! -f "$policy_path" ]; then
@@ -142,8 +179,21 @@ sentinel_policy_file_for_config() {
     return 1
   fi
 
-  sentinel_validate_policy_file "$policy_path" "$policy_ref" || return 1
-  echo "$policy_path"
+  policy_path_real=$(sentinel_realpath "$policy_path") || {
+    echo "::error::Unable to resolve policy_file path: ${policy_ref} (resolved to ${policy_path})" >&2
+    return 1
+  }
+
+  case "$policy_path_real" in
+    "$repo_root_real"/*) ;;
+    *)
+      echo "::error::policy_file must stay within repository root: ${policy_ref} (resolved to ${policy_path_real}; repo root ${repo_root_real})" >&2
+      return 1
+      ;;
+  esac
+
+  sentinel_validate_policy_file "$policy_path_real" "$policy_ref" || return 1
+  echo "$policy_path_real"
 }
 
 sentinel_governance_source_file() {

--- a/scripts/policy-loader.sh
+++ b/scripts/policy-loader.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Shared Sentinel policy/config helpers.
+#
+# Contract:
+# - .sentinel/config.yaml remains the runtime/tool config file.
+# - Optional config key `policy_file` points to a repository-relative YAML file.
+# - Governance policy keys are read from policy_file when that key is present
+#   there; otherwise they fall back to .sentinel/config.yaml for compatibility.
+# - No yq dependency: this intentionally supports the small YAML subset already
+#   used by Sentinel configs (top-level scalars, arrays, and simple maps).
+
+sentinel_trim_yaml_value() {
+  sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^[[:space:]]+|[[:space:]]+$//g' \
+    | tr -d '"' \
+    | tr -d "'"
+}
+
+sentinel_yaml_get() {
+  local file="$1" key="$2" default="${3:-}"
+  local val
+  val=$(grep -E "^[[:space:]]*${key}:" "$file" 2>/dev/null | head -1 | sentinel_trim_yaml_value || true)
+  echo "${val:-$default}"
+}
+
+sentinel_yaml_has_top_key() {
+  local file="$1" key="$2"
+  grep -Eq "^${key}:[[:space:]]*($|#|.*)" "$file" 2>/dev/null
+}
+
+sentinel_yaml_get_array() {
+  local file="$1" key="$2"
+  awk -v key="$key" '
+    $0 ~ "^[[:space:]]*" key ":[[:space:]]*($|#)" { in_array=1; next }
+    in_array && $0 ~ "^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*" { exit }
+    in_array && $0 ~ "^[[:space:]]*-" {
+      line=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      gsub(/["'\''"]/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      print line
+    }
+  ' "$file" 2>/dev/null || true
+}
+
+sentinel_yaml_get_map() {
+  local file="$1" key="$2"
+  awk -v key="$key" '
+    $0 ~ "^[[:space:]]*" key ":[[:space:]]*($|#)" { in_map=1; next }
+    in_map && $0 ~ "^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*" { exit }
+    in_map && $0 ~ "^[[:space:]]+[^#[:space:]][^:]*:[[:space:]]*" {
+      line=$0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      gsub(/["'\''"]/, "", line)
+      sub(/[[:space:]]*:[[:space:]]*/, "=", line)
+      sub(/[[:space:]]+$/, "", line)
+      print line
+    }
+  ' "$file" 2>/dev/null || true
+}
+
+sentinel_repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+sentinel_validate_policy_file() {
+  local file="$1" display="${2:-$1}"
+  local line line_no trimmed saw_root_key
+  line_no=0
+  saw_root_key=false
+
+  if [ ! -s "$file" ]; then
+    echo "::error::Malformed policy_file ${display}: file is empty" >&2
+    return 1
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$((line_no + 1))
+    line="${line%$'\r'}"
+
+    if [[ "$line" == *$'\t'* ]]; then
+      echo "::error::Malformed policy_file ${display}:${line_no}: tabs are not supported; use spaces" >&2
+      return 1
+    fi
+
+    trimmed=$(printf '%s' "$line" \
+      | sed -E 's/^[[:space:]]*#.*$//; s/[[:space:]]+#.*$//; s/^[[:space:]]+|[[:space:]]+$//g')
+    [ -z "$trimmed" ] && continue
+
+    if [[ "$line" != [[:space:]]* ]]; then
+      if ! [[ "$trimmed" =~ ^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*.*$ ]]; then
+        echo "::error::Malformed policy_file ${display}:${line_no}: expected top-level key mapping entry" >&2
+        return 1
+      fi
+      saw_root_key=true
+    else
+      if ! [[ "$trimmed" =~ ^-([[:space:]].*)?$|^[^:]+:[[:space:]]*.*$ ]]; then
+        echo "::error::Malformed policy_file ${display}:${line_no}: expected list item or map entry" >&2
+        return 1
+      fi
+    fi
+  done < "$file"
+
+  if [ "$saw_root_key" != true ]; then
+    echo "::error::Malformed policy_file ${display}: expected YAML mapping root" >&2
+    return 1
+  fi
+}
+
+sentinel_policy_file_for_config() {
+  local config_file="$1"
+  local policy_ref policy_path repo_root
+
+  policy_ref=$(sentinel_yaml_get "$config_file" "policy_file" "")
+  if [ -z "$policy_ref" ]; then
+    echo ""
+    return 0
+  fi
+
+  case "$policy_ref" in
+    *.yaml|*.yml) ;;
+    *)
+      echo "::error::policy_file must be a YAML file (.yaml or .yml): ${policy_ref}" >&2
+      return 1
+      ;;
+  esac
+
+  case "$policy_ref" in
+    /*)
+      echo "::error::policy_file must be repository-relative, not absolute: ${policy_ref}" >&2
+      return 1
+      ;;
+  esac
+
+  repo_root=$(sentinel_repo_root)
+  policy_path="${repo_root}/${policy_ref}"
+
+  if [ ! -f "$policy_path" ]; then
+    echo "::error::policy_file not found: ${policy_ref} (resolved to ${policy_path})" >&2
+    return 1
+  fi
+
+  sentinel_validate_policy_file "$policy_path" "$policy_ref" || return 1
+  echo "$policy_path"
+}
+
+sentinel_governance_source_file() {
+  local config_file="$1" key="$2"
+  local policy_file
+  policy_file=$(sentinel_policy_file_for_config "$config_file") || return 1
+
+  if [ -n "$policy_file" ] && sentinel_yaml_has_top_key "$policy_file" "$key"; then
+    echo "$policy_file"
+  else
+    echo "$config_file"
+  fi
+}
+
+sentinel_governance_get_array() {
+  local config_file="$1" key="$2" source_file
+  source_file=$(sentinel_governance_source_file "$config_file" "$key") || return 1
+  sentinel_yaml_get_array "$source_file" "$key"
+}
+
+sentinel_governance_get_map() {
+  local config_file="$1" key="$2" source_file
+  source_file=$(sentinel_governance_source_file "$config_file" "$key") || return 1
+  sentinel_yaml_get_map "$source_file" "$key"
+}

--- a/scripts/precheck-cascade.sh
+++ b/scripts/precheck-cascade.sh
@@ -6,31 +6,18 @@ set -euo pipefail
 
 CONFIG_FILE="${CONFIG_FILE:-.sentinel/config.yaml}"
 RESULTS_DIR="${RESULTS_DIR:-.sentinel/results}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 mkdir -p "$RESULTS_DIR"
 
-# YAML value reader (no yq dependency)
-yaml_get() {
-  local file="$1" key="$2" default="${3:-}"
-  local val=$(grep -E "^\s*${key}:" "$file" 2>/dev/null | head -1 | sed 's/^[^:]*:\s*//' | sed 's/\s*#.*//' | tr -d '"' | tr -d "'")
-  echo "${val:-$default}"
-}
-
-# Parse nested YAML cascade_map into key=value pairs
-parse_cascade_map() {
-  local file="$1"
-  sed -n "/^\s*cascade_map:/,/^\s*[a-z]/p" "$file" 2>/dev/null | \
-    { grep -E "^\s+[^ :]+:\s+" || true; } | \
-    sed 's/^\s*//' | \
-    sed 's/:\s*/=/' | \
-    sed 's/["\x27]//g' | \
-    sed 's/[[:space:]]*$//'
-}
+# YAML/policy helpers (no yq dependency)
+# shellcheck source=scripts/policy-loader.sh
+source "$SCRIPT_DIR/policy-loader.sh"
 
 echo "D-3: Cascade integrity"
 
-# Read cascade rules from config
-CASCADE_MAP=$(parse_cascade_map "$CONFIG_FILE")
+# Read cascade rules from policy_file when present, otherwise config
+CASCADE_MAP=$(sentinel_governance_get_map "$CONFIG_FILE" "cascade_map")
 
 if [ -z "$CASCADE_MAP" ]; then
   echo "No cascade rules configured — PASS"

--- a/scripts/precheck-changelog.sh
+++ b/scripts/precheck-changelog.sh
@@ -7,20 +7,13 @@ set -euo pipefail
 
 CONFIG_FILE="${CONFIG_FILE:-.sentinel/config.yaml}"
 RESULTS_DIR="${RESULTS_DIR:-.sentinel/results}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 mkdir -p "$RESULTS_DIR"
 
-# YAML helpers (no yq dependency)
-yaml_get() {
-  local file="$1" key="$2" default="${3:-}"
-  local val=$(grep -E "^\s*${key}:" "$file" 2>/dev/null | head -1 | sed 's/^[^:]*:\s*//' | sed 's/\s*#.*//' | tr -d '"' | tr -d "'")
-  echo "${val:-$default}"
-}
-
-yaml_get_array() {
-  local file="$1" key="$2"
-  sed -n "/^\s*${key}:/,/^\s*[a-z]/p" "$file" 2>/dev/null | { grep "^\s*-" || true; } | sed 's/^\s*-\s*//' | tr -d '"' | tr -d "'"
-}
+# YAML/policy helpers (no yq dependency)
+# shellcheck source=scripts/policy-loader.sh
+source "$SCRIPT_DIR/policy-loader.sh"
 
 echo "D-1: CHANGELOG check"
 
@@ -44,8 +37,8 @@ fi
 echo "Changed files in this commit/PR:"
 echo "$CHANGED_FILES" | head -20
 
-# Read governance files list from config
-GOVERNANCE_FILES=$(yaml_get_array "$CONFIG_FILE" "governance_files")
+# Read governance files list from policy_file when present, otherwise config
+GOVERNANCE_FILES=$(sentinel_governance_get_array "$CONFIG_FILE" "governance_files")
 if [ -z "$GOVERNANCE_FILES" ]; then
   echo "No governance_files configured — PASS"
   cat > "$RESULTS_DIR/d1-changelog.json" <<EOF
@@ -55,7 +48,7 @@ EOF
 fi
 
 # Read changelog file name (default: CHANGELOG.md)
-CHANGELOG_FILE=$(yaml_get "$CONFIG_FILE" "changelog_file" "CHANGELOG.md")
+CHANGELOG_FILE=$(sentinel_yaml_get "$CONFIG_FILE" "changelog_file" "CHANGELOG.md")
 
 # Check: did any governance file change?
 MODIFIED_GOV_FILES=()

--- a/scripts/precheck-terminology.sh
+++ b/scripts/precheck-terminology.sh
@@ -7,25 +7,18 @@ set -euo pipefail
 
 CONFIG_FILE="${CONFIG_FILE:-.sentinel/config.yaml}"
 RESULTS_DIR="${RESULTS_DIR:-.sentinel/results}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 mkdir -p "$RESULTS_DIR"
 
-# YAML helpers (no yq dependency)
-yaml_get() {
-  local file="$1" key="$2" default="${3:-}"
-  local val=$(grep -E "^\s*${key}:" "$file" 2>/dev/null | head -1 | sed 's/^[^:]*:\s*//' | sed 's/\s*#.*//' | tr -d '"' | tr -d "'")
-  echo "${val:-$default}"
-}
-
-yaml_get_array() {
-  local file="$1" key="$2"
-  sed -n "/^\s*${key}:/,/^\s*[a-z]/p" "$file" 2>/dev/null | { grep "^\s*-" || true; } | sed 's/^\s*-\s*//' | tr -d '"' | tr -d "'"
-}
+# YAML/policy helpers (no yq dependency)
+# shellcheck source=scripts/policy-loader.sh
+source "$SCRIPT_DIR/policy-loader.sh"
 
 echo "D-2: Terminology scan"
 
-# Read forbidden terms from config
-FORBIDDEN_TERMS=$(yaml_get_array "$CONFIG_FILE" "forbidden_terms")
+# Read forbidden terms from policy_file when present, otherwise config
+FORBIDDEN_TERMS=$(sentinel_governance_get_array "$CONFIG_FILE" "forbidden_terms")
 
 # Use defaults if not configured
 if [ -z "$FORBIDDEN_TERMS" ]; then
@@ -45,8 +38,8 @@ else
   echo "Read forbidden terms from config"
 fi
 
-# Read exclude patterns from config
-EXCLUDE_PATTERNS=$(yaml_get_array "$CONFIG_FILE" "terminology_exclude_patterns")
+# Read exclude patterns from policy_file when present, otherwise config
+EXCLUDE_PATTERNS=$(sentinel_governance_get_array "$CONFIG_FILE" "terminology_exclude_patterns")
 if [ -n "$EXCLUDE_PATTERNS" ]; then
   echo "Exclude patterns loaded: $(echo "$EXCLUDE_PATTERNS" | wc -l | tr -d ' ') patterns"
 fi
@@ -54,8 +47,9 @@ fi
 # Function: check if a filename matches any exclude pattern
 should_exclude() {
   local filepath="$1"
-  local basename
+  local basename normalized_path normalized_pattern
   basename=$(basename "$filepath")
+  normalized_path="${filepath#./}"
   
   if [ -z "$EXCLUDE_PATTERNS" ]; then
     return 1  # no patterns = don't exclude
@@ -63,7 +57,14 @@ should_exclude() {
   
   while IFS= read -r pattern; do
     [ -z "$pattern" ] && continue
+    normalized_pattern="${pattern#./}"
     # Use bash pattern matching (supports * and ? globs)
+    # Match repository-relative paths first for path-aware excludes.
+    # shellcheck disable=SC2254
+    case "$normalized_path" in
+      $normalized_pattern) return 0 ;;  # path match = exclude
+    esac
+    # Preserve legacy basename-style patterns.
     # shellcheck disable=SC2254
     case "$basename" in
       $pattern) return 0 ;;  # match = exclude

--- a/tests/test-policy-file.sh
+++ b/tests/test-policy-file.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+D1_SCRIPT="$ROOT_DIR/scripts/precheck-changelog.sh"
+D2_SCRIPT="$ROOT_DIR/scripts/precheck-terminology.sh"
+D3_SCRIPT="$ROOT_DIR/scripts/precheck-cascade.sh"
+
+PASS_COUNT=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "Expected output to contain: $needle" >&2
+    echo "Actual output:" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -q -- "$needle" "$file"; then
+    echo "Expected $file to contain: $needle" >&2
+    echo "Actual file:" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "ok - $1"
+}
+
+init_repo() {
+  local dir="$1"
+  mkdir -p "$dir/.sentinel/results"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email "sentinel-test@example.invalid"
+  git -C "$dir" config user.name "Sentinel Test"
+}
+
+commit_all() {
+  local dir="$1"
+  local msg="$2"
+  git -C "$dir" add .
+  git -C "$dir" commit -q -m "$msg"
+}
+
+run_script_capture() {
+  local dir="$1"
+  local script="$2"
+  set +e
+  OUTPUT=$(cd "$dir" && bash "$script" 2>&1)
+  CODE=$?
+  set -e
+}
+
+write_base_config() {
+  local dir="$1"
+  mkdir -p "$dir/.sentinel"
+  cat > "$dir/.sentinel/config.yaml"
+}
+
+test_no_policy_file_preserves_config_only_forbidden_terms() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - CONFIGONLYBLOCK
+YAML
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "CONFIGONLYBLOCK appears here" > "$repo/sample.md"
+  commit_all "$repo" "introduce config default term"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should fail on config-only forbidden_terms"
+  fi
+  assert_file_contains "$repo/.sentinel/results/d2-terminology.json" "CONFIGONLYBLOCK"
+  pass "no policy_file preserves config-only forbidden_terms behavior"
+}
+
+test_policy_file_loads_forbidden_terms() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/sentinel-policy.yaml
+YAML
+  cat > "$repo/governance/sentinel-policy.yaml" <<'YAML'
+forbidden_terms:
+  - POLICYBLOCK
+YAML
+  echo "clean" > "$repo/policy.md"
+  commit_all "$repo" "base"
+  echo "POLICYBLOCK appears here" > "$repo/policy.md"
+  commit_all "$repo" "introduce policy term"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should fail on forbidden_terms loaded from policy_file"
+  fi
+  assert_file_contains "$repo/.sentinel/results/d2-terminology.json" "POLICYBLOCK"
+  pass "policy_file loads forbidden_terms"
+}
+
+test_policy_file_loads_terminology_exclude_patterns_with_config_term_fallback() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance" "$repo/docs"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/sentinel-policy.yaml
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  cat > "$repo/governance/sentinel-policy.yaml" <<'YAML'
+terminology_exclude_patterns:
+  - docs/excluded.md
+YAML
+  echo "clean" > "$repo/docs/excluded.md"
+  commit_all "$repo" "base"
+  echo "CONFIGTERM appears in excluded policy path" > "$repo/docs/excluded.md"
+  commit_all "$repo" "change excluded path"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should pass when terminology_exclude_patterns come from policy_file"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  pass "policy_file loads terminology_exclude_patterns and falls back absent forbidden_terms to config"
+}
+
+test_policy_file_loads_governance_files() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/sentinel-policy.yaml
+changelog_file: CHANGELOG.md
+YAML
+  cat > "$repo/governance/sentinel-policy.yaml" <<'YAML'
+governance_files:
+  - governance/policy.md
+YAML
+  echo "# Changelog" > "$repo/CHANGELOG.md"
+  echo "base" > "$repo/governance/policy.md"
+  commit_all "$repo" "base"
+  echo "changed" > "$repo/governance/policy.md"
+  commit_all "$repo" "change governance policy"
+
+  run_script_capture "$repo" "$D1_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-1 should fail when governance_files loaded from policy_file changed without changelog"
+  fi
+  assert_file_contains "$repo/.sentinel/results/d1-changelog.json" "governance/policy.md was modified but CHANGELOG.md was not updated"
+  pass "policy_file loads governance_files"
+}
+
+test_policy_file_loads_cascade_map() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/sentinel-policy.yaml
+YAML
+  cat > "$repo/governance/sentinel-policy.yaml" <<'YAML'
+cascade_map:
+  "governance/source.md": "governance/target.md"
+YAML
+  echo "base" > "$repo/governance/source.md"
+  commit_all "$repo" "base"
+  echo "changed" > "$repo/governance/source.md"
+  commit_all "$repo" "change source"
+
+  run_script_capture "$repo" "$D3_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-3 should fail when cascade_map loaded from policy_file points to missing target"
+  fi
+  assert_contains "$OUTPUT" "Target governance/target.md does not exist"
+  pass "policy_file loads cascade_map"
+}
+
+test_missing_policy_file_fails_clearly() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/missing-policy.yaml
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "clean change" > "$repo/sample.md"
+  commit_all "$repo" "change"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should fail when policy_file is missing"
+  fi
+  assert_contains "$OUTPUT" "policy_file not found"
+  assert_contains "$OUTPUT" "governance/missing-policy.yaml"
+  pass "missing policy_file fails clearly"
+}
+
+test_malformed_policy_file_fails_clearly() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/malformed-policy.yaml
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  cat > "$repo/governance/malformed-policy.yaml" <<'YAML'
+forbidden_terms
+  - POLICYTERM
+YAML
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "clean change" > "$repo/sample.md"
+  commit_all "$repo" "change"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should fail when policy_file is malformed"
+  fi
+  assert_contains "$OUTPUT" "Malformed policy_file"
+  assert_contains "$OUTPUT" "governance/malformed-policy.yaml"
+  pass "malformed policy_file fails clearly"
+}
+
+test_path_level_terminology_excludes_match_nested_paths() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance/archive/old"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - PATHBLOCK
+terminology_exclude_patterns:
+  - governance/archive/**
+YAML
+  echo "clean" > "$repo/governance/archive/old/spec.md"
+  commit_all "$repo" "base"
+  echo "PATHBLOCK is intentionally archived" > "$repo/governance/archive/old/spec.md"
+  commit_all "$repo" "change archived path"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should pass when path-level terminology_exclude_patterns match nested paths"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  pass "path-level terminology excludes match nested paths"
+}
+
+test_policy_file_loads_forbidden_terms
+test_policy_file_loads_terminology_exclude_patterns_with_config_term_fallback
+test_policy_file_loads_governance_files
+test_policy_file_loads_cascade_map
+test_missing_policy_file_fails_clearly
+test_malformed_policy_file_fails_clearly
+test_path_level_terminology_excludes_match_nested_paths
+test_no_policy_file_preserves_config_only_forbidden_terms
+
+echo "All ${PASS_COUNT} policy_file tests passed"

--- a/tests/test-policy-file.sh
+++ b/tests/test-policy-file.sh
@@ -254,6 +254,116 @@ YAML
   pass "malformed policy_file fails clearly"
 }
 
+test_policy_file_parent_escape_is_rejected() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+policy_file: ../outside-policy.yaml
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  cat > "$tmp/outside-policy.yaml" <<'YAML'
+forbidden_terms:
+  - OUTSIDEBLOCK
+YAML
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "OUTSIDEBLOCK appears here" > "$repo/sample.md"
+  commit_all "$repo" "change"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should reject policy_file that escapes repository root via .."
+  fi
+  assert_contains "$OUTPUT" "policy_file must stay within repository root"
+  assert_contains "$OUTPUT" "../outside-policy.yaml"
+  pass "policy_file parent-directory escape is rejected"
+}
+
+test_policy_file_symlink_escape_is_rejected() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/governance"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/sentinel-policy.yaml
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  cat > "$tmp/outside-policy.yaml" <<'YAML'
+forbidden_terms:
+  - OUTSIDEBLOCK
+YAML
+  ln -s "$tmp/outside-policy.yaml" "$repo/governance/sentinel-policy.yaml"
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "OUTSIDEBLOCK appears here" > "$repo/sample.md"
+  commit_all "$repo" "change"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should reject policy_file symlink that escapes repository root"
+  fi
+  assert_contains "$OUTPUT" "policy_file must stay within repository root"
+  assert_contains "$OUTPUT" "governance/sentinel-policy.yaml"
+  pass "policy_file symlink escape is rejected"
+}
+
+test_absolute_policy_file_path_is_rejected() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  cat > "$tmp/outside-policy.yaml" <<'YAML'
+forbidden_terms:
+  - OUTSIDEBLOCK
+YAML
+  write_base_config "$repo" <<YAML
+policy_file: $tmp/outside-policy.yaml
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "clean change" > "$repo/sample.md"
+  commit_all "$repo" "change"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should reject absolute policy_file path"
+  fi
+  assert_contains "$OUTPUT" "policy_file must be repository-relative, not absolute"
+  assert_contains "$OUTPUT" "$tmp/outside-policy.yaml"
+  pass "absolute policy_file path is rejected"
+}
+
+test_non_yaml_policy_file_path_is_rejected() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+policy_file: governance/sentinel-policy.txt
+forbidden_terms:
+  - CONFIGTERM
+YAML
+  echo "clean" > "$repo/sample.md"
+  commit_all "$repo" "base"
+  echo "clean change" > "$repo/sample.md"
+  commit_all "$repo" "change"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should reject non-YAML policy_file path"
+  fi
+  assert_contains "$OUTPUT" "policy_file must be a YAML file (.yaml or .yml)"
+  assert_contains "$OUTPUT" "governance/sentinel-policy.txt"
+  pass "non-YAML policy_file path is rejected"
+}
+
 test_path_level_terminology_excludes_match_nested_paths() {
   local tmp repo
   tmp="$(mktemp -d)"
@@ -286,6 +396,10 @@ test_policy_file_loads_governance_files
 test_policy_file_loads_cascade_map
 test_missing_policy_file_fails_clearly
 test_malformed_policy_file_fails_clearly
+test_policy_file_parent_escape_is_rejected
+test_policy_file_symlink_escape_is_rejected
+test_absolute_policy_file_path_is_rejected
+test_non_yaml_policy_file_path_is_rejected
 test_path_level_terminology_excludes_match_nested_paths
 test_no_policy_file_preserves_config_only_forbidden_terms
 


### PR DESCRIPTION
## Summary

Adds real `policy_file` support to Sentinel shared scripts so governance policy keys can move out of `.sentinel/config.yaml` without becoming inert configuration.

This is the shared-tooling prerequisite for HK Acceptance Phase 2 F-003. It does not migrate `hl-contracts` yet.

## Behavior

- `.sentinel/config.yaml` can reference a repository-relative YAML file with `policy_file`.
- Governance keys are loaded from that policy file when present:
  - `forbidden_terms`
  - `terminology_exclude_patterns`
  - `governance_files`
  - `cascade_map`
- Missing keys fall back to `.sentinel/config.yaml` for backward compatibility.
- Tool/runtime keys continue to live in `.sentinel/config.yaml`.
- Missing, absolute, non-YAML, empty, or malformed policy files fail clearly.
- `terminology_exclude_patterns` now match repository-relative paths first, while preserving legacy basename matching.

## Verification

```bash
./tests/test-policy-file.sh
```

Observed:

```text
All 8 policy_file tests passed
```

```bash
for t in tests/*.sh; do echo "===== $t ====="; bash "$t"; done
```

Observed:

```text
All 7 D-7/D-8 tests passed
llm-review provider router tests passed
All 8 policy_file tests passed
```

```bash
bash -n scripts/*.sh .sentinel/checks/*.sh tests/*.sh
git diff --check
grep -n '[[:blank:]]$' scripts/policy-loader.sh tests/test-policy-file.sh
```

Observed:

- `bash -n`: exit `0`
- `git diff --check`: exit `0`
- trailing whitespace check: no matches, exit `1` as expected for grep no-match

## Coordination Notes

NODE-A CTO completed the initial implementation and validation but could not write `.git/` from its Codex runtime. NODE-M restored the CTO diff into a clean local checkout, hardened one test so config-only custom `forbidden_terms` use a non-default term, reran validation, committed, and opened this PR.

After this PR merges, the next PR should migrate `hl-contracts` policy keys into a governance policy SSOT file and reference it through `policy_file`.

