### PR TITLE
Clarify D-2 policy source log

### DIFF
--- a/scripts/precheck-terminology.sh
+++ b/scripts/precheck-terminology.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # D-2: Terminology scan
-# Reads forbidden terms from .sentinel/config.yaml
+# Reads forbidden terms from policy_file when present, otherwise .sentinel/config.yaml
 # Supports terminology_exclude_patterns to skip governance spec files
 
 CONFIG_FILE="${CONFIG_FILE:-.sentinel/config.yaml}"
@@ -18,7 +18,21 @@ source "$SCRIPT_DIR/policy-loader.sh"
 echo "D-2: Terminology scan"
 
 # Read forbidden terms from policy_file when present, otherwise config
-FORBIDDEN_TERMS=$(sentinel_governance_get_array "$CONFIG_FILE" "forbidden_terms")
+FORBIDDEN_TERMS_SOURCE_FILE=$(sentinel_governance_source_file "$CONFIG_FILE" "forbidden_terms")
+FORBIDDEN_TERMS=$(sentinel_yaml_get_array "$FORBIDDEN_TERMS_SOURCE_FILE" "forbidden_terms")
+
+display_repo_relative_path() {
+  local path="$1"
+  local repo_root repo_root_real
+  repo_root=$(sentinel_repo_root)
+  repo_root_real=$(sentinel_realpath "$repo_root" 2>/dev/null || echo "$repo_root")
+
+  case "$path" in
+    "$repo_root"/*) echo "${path#"$repo_root"/}" ;;
+    "$repo_root_real"/*) echo "${path#"$repo_root_real"/}" ;;
+    *) echo "$path" ;;
+  esac
+}
 
 # Use defaults if not configured
 if [ -z "$FORBIDDEN_TERMS" ]; then
@@ -35,7 +49,11 @@ TERMS
 )
   echo "Using default forbidden terms"
 else
-  echo "Read forbidden terms from config"
+  if [ "$FORBIDDEN_TERMS_SOURCE_FILE" = "$CONFIG_FILE" ]; then
+    echo "Read forbidden terms from config"
+  else
+    echo "Read forbidden terms from policy_file: $(display_repo_relative_path "$FORBIDDEN_TERMS_SOURCE_FILE")"
+  fi
 fi
 
 # Read exclude patterns from policy_file when present, otherwise config

--- a/tests/test-policy-file.sh
+++ b/tests/test-policy-file.sh
@@ -88,6 +88,7 @@ YAML
   if [ "$CODE" -eq 0 ]; then
     fail "D-2 should fail on config-only forbidden_terms"
   fi
+  assert_contains "$OUTPUT" "Read forbidden terms from config"
   assert_file_contains "$repo/.sentinel/results/d2-terminology.json" "CONFIGONLYBLOCK"
   pass "no policy_file preserves config-only forbidden_terms behavior"
 }
@@ -114,6 +115,7 @@ YAML
   if [ "$CODE" -eq 0 ]; then
     fail "D-2 should fail on forbidden_terms loaded from policy_file"
   fi
+  assert_contains "$OUTPUT" "Read forbidden terms from policy_file: governance/sentinel-policy.yaml"
   assert_file_contains "$repo/.sentinel/results/d2-terminology.json" "POLICYBLOCK"
   pass "policy_file loads forbidden_terms"
 }


### PR DESCRIPTION
## Summary

- Clarify D-2 terminology scan output so it reports whether `forbidden_terms` came from `policy_file` or config fallback.
- Add policy-file and config fallback assertions to `tests/test-policy-file.sh`.
- Preserve default forbidden-term behavior when neither policy nor config defines terms.

## Verification

CTO / NODE-A:

- RED: `./tests/test-policy-file.sh` failed before implementation because D-2 still printed `Read forbidden terms from config` for a policy_file source.
- GREEN: `./tests/test-policy-file.sh` -> `All 12 policy_file tests passed`.
- Full: `for t in tests/*.sh; do echo "===== $t ====="; bash "$t"; done` -> exit `0`.
- Syntax: `bash -n scripts/*.sh .sentinel/checks/*.sh tests/*.sh` -> exit `0`.
- Diff check: `git diff --check` -> exit `0`.

NODE-M recovery verification on commit `3abf699debe67934e59f2eb680740f0e2522250e`:

- `./tests/test-policy-file.sh` -> `All 12 policy_file tests passed`.
- Full `tests/*.sh` -> exit `0`.
- `bash -n scripts/*.sh .sentinel/checks/*.sh tests/*.sh` -> exit `0`.
- `git diff --check` -> exit `0`.
- `hl-contracts` integration sanity using this branch's D-2 script:
  - output includes `Read forbidden terms from policy_file: governance/sentinel-policy.yaml`
  - `✓ No forbidden terms detected`

## Residual

- Existing D-7/D-8 tests still emit known `issues[@]` / `warnings[@]` diagnostic lines while exiting `0`; this PR does not touch D-7/D-8.
