### PR TITLE
fix(sentinel): cascade_map block-style + terminology path-aware exclude

### DIFF
--- a/scripts/policy-loader.sh
+++ b/scripts/policy-loader.sh
@@ -47,17 +47,53 @@ sentinel_yaml_get_array() {
 sentinel_yaml_get_map() {
   local file="$1" key="$2"
   awk -v key="$key" '
-    $0 ~ "^[[:space:]]*" key ":[[:space:]]*($|#)" { in_map=1; next }
+    function emit(k, v) {
+      sub(/^[[:space:]]+/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      gsub(/["'\''"]/, "", v)
+      if (v == "[]" || v == "{}") return
+      if (k != "" && v != "") print k "=" v
+    }
+
+    $0 ~ "^[[:space:]]*" key ":[[:space:]]*($|#)" { in_map=1; cur_key=""; cur_indent=-1; next }
     in_map && $0 ~ "^[A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*" { exit }
-    in_map && $0 ~ "^[[:space:]]+[^#[:space:]][^:]*:[[:space:]]*" {
+
+    in_map && $0 ~ "^[[:space:]]+[^#[:space:]-][^:]*:[[:space:]]*(#|$)" {
+      line=$0
+      sub(/[[:space:]]+#.*$/, "", line)
+      match(line, /^[[:space:]]+/); cur_indent=RLENGTH
+      sub(/^[[:space:]]+/, "", line)
+      sub(/:[[:space:]]*$/, "", line)
+      gsub(/["'\''"]/, "", line)
+      cur_key=line
+      next
+    }
+
+    in_map && cur_key != "" && $0 ~ "^[[:space:]]+-[[:space:]]+" {
+      line=$0
+      match(line, /^[[:space:]]+/)
+      if (RLENGTH <= cur_indent) { cur_key=""; next }
+      sub(/^[[:space:]]+-[[:space:]]+/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      emit(cur_key, line)
+      next
+    }
+
+    in_map && $0 ~ "^[[:space:]]+[^#[:space:]-][^:]*:[[:space:]]+[^[:space:]]" {
       line=$0
       sub(/^[[:space:]]+/, "", line)
       sub(/[[:space:]]+#.*$/, "", line)
       gsub(/["'\''"]/, "", line)
       sub(/[[:space:]]*:[[:space:]]*/, "=", line)
-      sub(/[[:space:]]+$/, "", line)
+      cur_key=""
+      val=line; sub(/^[^=]+=/, "", val)
+      if (val == "[]" || val == "{}") next
       print line
+      next
     }
+
+    in_map && /^[^[:space:]]/ { exit }
+    in_map && cur_key != "" && /^$/ { cur_key="" }
   ' "$file" 2>/dev/null || true
 }
 

--- a/scripts/precheck-terminology.sh
+++ b/scripts/precheck-terminology.sh
@@ -76,17 +76,20 @@ should_exclude() {
   while IFS= read -r pattern; do
     [ -z "$pattern" ] && continue
     normalized_pattern="${pattern#./}"
-    # Use bash pattern matching (supports * and ? globs)
-    # Match repository-relative paths first for path-aware excludes.
-    # shellcheck disable=SC2254
-    case "$normalized_path" in
-      $normalized_pattern) return 0 ;;  # path match = exclude
-    esac
-    # Preserve legacy basename-style patterns.
-    # shellcheck disable=SC2254
-    case "$basename" in
-      $pattern) return 0 ;;  # match = exclude
-    esac
+
+    if [[ "$normalized_pattern" == */* ]]; then
+      # Path-aware: use git pathspec :(glob) to honor `**` recursion incl. zero-depth.
+      if git ls-files --error-unmatch -- ":(glob)${normalized_pattern}" 2>/dev/null \
+           | grep -Fxq -- "$normalized_path"; then
+        return 0
+      fi
+    else
+      # Legacy basename: preserve existing semantics for `*-rules.md` / `AI_MEMORY.md` / etc.
+      # shellcheck disable=SC2254
+      case "$basename" in
+        $pattern) return 0 ;;  # match = exclude
+      esac
+    fi
   done <<< "$EXCLUDE_PATTERNS"
   
   return 1  # no match = don't exclude

--- a/tests/test-policy-file.sh
+++ b/tests/test-policy-file.sh
@@ -392,6 +392,314 @@ YAML
   pass "path-level terminology excludes match nested paths"
 }
 
+test_d3_cascade_block_list_full_tzhOS_shape() {
+  local tmp repo result line_count
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+cascade_map:
+  "MIRA-001.md":
+    - "SAAC-001.md"
+    - "BOOTSTRAP.md"
+    - "CONTEXT.md"
+    - "CONSEN-SPEC-001.md"
+  "SAAC-001.md":
+    - "CONTEXT.md"
+    - "BOOTSTRAP.md"
+  "00-CHARTER/mission-telos.md":
+    - "CONTEXT.md"
+    - "BOOTSTRAP.md"
+  "00-CHARTER/governance.md":
+    - "CONTEXT.md"
+    - "BOOTSTRAP.md"
+    - "RULINGS.md"
+    - "CHANGELOG.md"
+  "00-CHARTER/collaboration-standard.md":
+    - "CONTEXT.md"
+    - "BOOTSTRAP.md"
+  "00-CHARTER/interface-standard.md":
+    - "CONTEXT.md"
+    - "BOOTSTRAP.md"
+    - "20-DIGITAL-WORKBENCH/templates/interface-declaration.template.md"
+  "00-CHARTER/playbooks/decision-gate.md":
+    - "CONTEXT.md"
+    - "RULINGS.md"
+  "00-CHARTER/playbooks/monthly-audit-review.md":
+    - "CONTEXT.md"
+  "40-VAH/VAH-001.md":
+    - "INDEX.md"
+    - "MASTER-OVERVIEW.md"
+    - "CONTEXT.md"
+    - "ai/VAH-METHODOLOGY.md"
+    - "40-VAH/GATE-EVIDENCE-ENVELOPE-v0.md"
+  "ai/VAH-METHODOLOGY.md":
+    - "INDEX.md"
+    - "MASTER-OVERVIEW.md"
+    - "CONTEXT.md"
+    - "ai/PLAYBOOK.md"
+    - "40-VAH/VAH-001.md"
+    - "40-VAH/GATE-EVIDENCE-ENVELOPE-v0.md"
+  "40-VAH/GATE-EVIDENCE-ENVELOPE-v0.md":
+    - "INDEX.md"
+    - "RULINGS.md"
+    - "40-VAH/VAH-001.md"
+    - "ai/VAH-METHODOLOGY.md"
+YAML
+
+  source "$ROOT_DIR/scripts/policy-loader.sh"
+  result=$(sentinel_yaml_get_map "$repo/.sentinel/config.yaml" "cascade_map")
+  line_count=$(printf '%s\n' "$result" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$line_count" -eq 35 ] || fail "expected 35 cascade edges, got $line_count"
+  assert_contains "$result" "MIRA-001.md=SAAC-001.md"
+  assert_contains "$result" "00-CHARTER/interface-standard.md=20-DIGITAL-WORKBENCH/templates/interface-declaration.template.md"
+  assert_contains "$result" "40-VAH/GATE-EVIDENCE-ENVELOPE-v0.md=ai/VAH-METHODOLOGY.md"
+  if printf '%s\n' "$result" | grep -Eq '=$'; then
+    fail "cascade block-list output must not contain empty targets"
+  fi
+  if printf '%s\n' "$result" | grep -Ev '^[^=]+=[^=]+$' | grep -q .; then
+    fail "cascade block-list output contains malformed edge"
+  fi
+  rm -rf "$tmp"
+  pass "cascade_map block-style list expands tzhOS 35 edges"
+}
+
+test_d3_cascade_flow_scalar_hl_contracts_shape() {
+  local tmp repo result line_count
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+cascade_map:
+  "TRACEABILITY.yaml": "CHANGELOG.md"
+  "governance/RULINGS.md": "CHANGELOG.md"
+YAML
+
+  source "$ROOT_DIR/scripts/policy-loader.sh"
+  result=$(sentinel_yaml_get_map "$repo/.sentinel/config.yaml" "cascade_map")
+  line_count=$(printf '%s\n' "$result" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$line_count" -eq 2 ] || fail "expected 2 flow scalar edges, got $line_count"
+  assert_contains "$result" "TRACEABILITY.yaml=CHANGELOG.md"
+  assert_contains "$result" "governance/RULINGS.md=CHANGELOG.md"
+  rm -rf "$tmp"
+  pass "cascade_map flow-style scalar remains compatible"
+}
+
+test_d3_cascade_inline_empty_map() {
+  local tmp repo result line_count
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+cascade_map: {}
+YAML
+
+  source "$ROOT_DIR/scripts/policy-loader.sh"
+  result=$(sentinel_yaml_get_map "$repo/.sentinel/config.yaml" "cascade_map")
+  line_count=$(printf '%s\n' "$result" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$line_count" -eq 0 ] || fail "expected empty inline map to produce 0 edges, got $line_count"
+  rm -rf "$tmp"
+  pass "cascade_map inline empty map remains empty"
+}
+
+test_d3_cascade_missing_section() {
+  local tmp repo result line_count
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - MISSINGSECTIONTERM
+YAML
+
+  source "$ROOT_DIR/scripts/policy-loader.sh"
+  result=$(sentinel_yaml_get_map "$repo/.sentinel/config.yaml" "cascade_map")
+  line_count=$(printf '%s\n' "$result" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$line_count" -eq 0 ] || fail "expected missing cascade_map section to produce 0 edges, got $line_count"
+  rm -rf "$tmp"
+  pass "missing cascade_map section remains empty"
+}
+
+test_d3_cascade_inline_empty_list_regression() {
+  local tmp repo result line_count
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+cascade_map:
+  "FOO.md": []
+YAML
+
+  source "$ROOT_DIR/scripts/policy-loader.sh"
+  result=$(sentinel_yaml_get_map "$repo/.sentinel/config.yaml" "cascade_map")
+  line_count=$(printf '%s\n' "$result" | awk 'NF { count++ } END { print count + 0 }')
+  [ "$line_count" -eq 0 ] || fail "expected inline empty list to produce 0 edges, got $line_count"
+  rm -rf "$tmp"
+  pass "cascade_map inline empty list does not emit false target"
+}
+
+test_d2_exclude_slash_zero_depth() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/40-VAH"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - PATHBLOCK
+terminology_exclude_patterns:
+  - 40-VAH/**/*.md
+YAML
+  echo "clean" > "$repo/40-VAH/foo.md"
+  commit_all "$repo" "base"
+  echo "PATHBLOCK intentionally excluded" > "$repo/40-VAH/foo.md"
+  commit_all "$repo" "change zero-depth excluded file"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should pass when slash pattern excludes zero-depth path"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  rm -rf "$tmp"
+  pass "terminology slash pattern excludes zero-depth path"
+}
+
+test_d2_exclude_slash_multi_depth() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/40-VAH/observations"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - PATHBLOCK
+terminology_exclude_patterns:
+  - 40-VAH/**/*.md
+YAML
+  echo "clean" > "$repo/40-VAH/observations/bar.md"
+  commit_all "$repo" "base"
+  echo "PATHBLOCK intentionally excluded" > "$repo/40-VAH/observations/bar.md"
+  commit_all "$repo" "change multi-depth excluded file"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should pass when slash pattern excludes multi-depth path"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  rm -rf "$tmp"
+  pass "terminology slash pattern excludes multi-depth path"
+}
+
+test_d2_exclude_basename_legacy_anywhere() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/docs"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - BASEBLOCK
+terminology_exclude_patterns:
+  - "*-rules.md"
+YAML
+  echo "clean" > "$repo/docs/lint-rules.md"
+  commit_all "$repo" "base"
+  echo "BASEBLOCK intentionally excluded" > "$repo/docs/lint-rules.md"
+  commit_all "$repo" "change basename excluded file"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should preserve basename glob excludes in nested directories"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  rm -rf "$tmp"
+  pass "terminology basename glob excludes nested filename"
+}
+
+test_d2_exclude_basename_anchor_anywhere() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/nested"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - BASEBLOCK
+terminology_exclude_patterns:
+  - AI_MEMORY.md
+YAML
+  echo "clean" > "$repo/nested/AI_MEMORY.md"
+  commit_all "$repo" "base"
+  echo "BASEBLOCK intentionally excluded" > "$repo/nested/AI_MEMORY.md"
+  commit_all "$repo" "change basename anchored file"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should preserve exact basename excludes in nested directories"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  rm -rf "$tmp"
+  pass "terminology exact basename excludes nested filename"
+}
+
+test_d2_exclude_no_match() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/40-PPR"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - PATHBLOCK
+terminology_exclude_patterns:
+  - 40-VAH/**/*.md
+YAML
+  echo "clean" > "$repo/40-PPR/PPR.md"
+  commit_all "$repo" "base"
+  echo "PATHBLOCK should not be excluded" > "$repo/40-PPR/PPR.md"
+  commit_all "$repo" "change non-matching path"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -eq 0 ]; then
+    fail "D-2 should fail when slash pattern does not match changed file"
+  fi
+  assert_file_contains "$repo/.sentinel/results/d2-terminology.json" "PATHBLOCK"
+  rm -rf "$tmp"
+  pass "terminology slash pattern does not exclude unrelated path"
+}
+
+test_d2_exclude_path_basename_conflict_either_wins() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  mkdir -p "$repo/40-VAH"
+  write_base_config "$repo" <<'YAML'
+forbidden_terms:
+  - PATHBLOCK
+terminology_exclude_patterns:
+  - 40-VAH/**/*.md
+  - "*-rules.md"
+YAML
+  echo "clean" > "$repo/40-VAH/foo-rules.md"
+  commit_all "$repo" "base"
+  echo "PATHBLOCK intentionally excluded" > "$repo/40-VAH/foo-rules.md"
+  commit_all "$repo" "change path and basename excluded file"
+
+  run_script_capture "$repo" "$D2_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-2 should exclude when either slash pattern or basename pattern matches"
+  fi
+  assert_contains "$OUTPUT" "Excluded 1 files by terminology_exclude_patterns"
+  rm -rf "$tmp"
+  pass "terminology excludes when path or basename pattern matches"
+}
+
 test_policy_file_loads_forbidden_terms
 test_policy_file_loads_terminology_exclude_patterns_with_config_term_fallback
 test_policy_file_loads_governance_files
@@ -404,5 +712,16 @@ test_absolute_policy_file_path_is_rejected
 test_non_yaml_policy_file_path_is_rejected
 test_path_level_terminology_excludes_match_nested_paths
 test_no_policy_file_preserves_config_only_forbidden_terms
+test_d3_cascade_block_list_full_tzhOS_shape
+test_d3_cascade_flow_scalar_hl_contracts_shape
+test_d3_cascade_inline_empty_map
+test_d3_cascade_missing_section
+test_d3_cascade_inline_empty_list_regression
+test_d2_exclude_slash_zero_depth
+test_d2_exclude_slash_multi_depth
+test_d2_exclude_basename_legacy_anywhere
+test_d2_exclude_basename_anchor_anywhere
+test_d2_exclude_no_match
+test_d2_exclude_path_basename_conflict_either_wins
 
 echo "All ${PASS_COUNT} policy_file tests passed"


### PR DESCRIPTION
## Problem

Two independent gaps surfaced via downstream tzhOS PR #98 envelope-v1-path investigation:

- D-3: `policy-loader.sh::sentinel_yaml_get_map` does not expand block-style mapping-of-list. tzhOS `cascade_map` now has 11 parents / 35 edges, but the current parser yields parent-only `source=` lines with empty targets.
- D-2: `should_exclude` path-aware branch uses bash `case` glob. Bash treats `**` as ordinary `*` in this context, so `dir/**/*.md` does not cover zero-depth paths like `dir/foo.md`.

## Root Causes

D-3 parsed simple mapping entries only. A parent key such as `"MIRA-001.md":` was treated as a scalar map entry, while its nested list items were ignored.

D-2 matched repository-relative paths using shell pattern matching. That preserves some nested behavior, but it does not provide Git pathspec `**` semantics for slash-containing patterns.

## Fix Summary

### D-3

- Extend `sentinel_yaml_get_map` with an awk state machine that tracks the current parent key and indentation, then emits one `KEY=VALUE` line per list item under a block-style mapping-of-list parent.
- Guard against inline empty list `[]` and inline empty map `{}` so they do not emit false targets such as `KEY=[]`.
- Keep existing flow-style `KEY: VALUE` and empty-inline-map `cascade_map: {}` behavior compatible.

### D-2

- Split exclude matching by pattern shape:
  - Slash patterns use `git ls-files --error-unmatch -- :(glob)PATTERN` plus `grep -Fxq` against the repo-relative path.
  - No-slash patterns keep the legacy basename `case` branch, preserving `*-rules.md`, `AI_MEMORY.md`, and `CONSEN-SPEC-*.md` semantics.

## Tests

`tests/test-policy-file.sh` adds 11 cases:

- 5 `cascade_map` cases covering block-style mapping-of-list, flow scalar compatibility, inline empty `{}`, missing section, and inline empty list `[]` regression.
- 6 terminology exclude cases covering slash pattern zero-depth, slash pattern multi-depth, legacy basename any-dir, exact basename any-dir, no-match, and path-vs-basename conflict.

Validation:

```text
bash tests/test-policy-file.sh
All 23 policy_file tests passed
```

Real-repo dry-run:

```text
tzhOS cascade_map: 35 cascade edges
hl-contracts cascade_map: 4 cascade edges
```

## Compatibility / Limitations

- YAML subset unchanged: scalar values must not embed unescaped quotes; the existing quote stripping behavior is preserved.
- Path matching for slash patterns relies on `git ls-files`, which assumes the script is run from a repo root with files indexed. This matches the current caller workflow.
- Extreme Git paths, such as filenames containing newlines or control characters, remain out of scope and undefined.

## Rollout / Risk

- Downstream callers reference `huanlongAI/sentinel-shared/.github/workflows/consistency-sentinel.yml@main`; merge takes effect on the next caller run.
- D-3 first real execution on configs that previously had silent PASS may surface source-only cascade warning output. Reviewers should expect a one-time warning fan-out.
- D-2 regression risk on existing basename patterns is contained because the legacy basename branch is preserved unchanged for no-slash patterns.

## Follow-ups

- Policy source observability: add cascade_map and exclude_patterns log lines showing whether values came from `.sentinel/config.yaml` or the resolved `policy_file`. PR #50 introduced this for `forbidden_terms` only.
- Cache per-pattern `git ls-files` results if exclude pattern count grows.
