### PR TITLE
fix(sentinel): avoid D-1 broken pipe on large diffs

### DIFF
--- a/scripts/precheck-changelog.sh
+++ b/scripts/precheck-changelog.sh
@@ -35,7 +35,7 @@ EOF
 fi
 
 echo "Changed files in this commit/PR:"
-echo "$CHANGED_FILES" | head -20
+sed -n '1,20p' <<< "$CHANGED_FILES"
 
 # Read governance files list from policy_file when present, otherwise config
 GOVERNANCE_FILES=$(sentinel_governance_get_array "$CONFIG_FILE" "governance_files")
@@ -54,7 +54,7 @@ CHANGELOG_FILE=$(sentinel_yaml_get "$CONFIG_FILE" "changelog_file" "CHANGELOG.md
 MODIFIED_GOV_FILES=()
 while IFS= read -r gov_file; do
   [ -z "$gov_file" ] && continue
-  if echo "$CHANGED_FILES" | grep -q "^${gov_file}$"; then
+  if grep -qxF "$gov_file" <<< "$CHANGED_FILES"; then
     MODIFIED_GOV_FILES+=("$gov_file")
   fi
 done <<< "$GOVERNANCE_FILES"
@@ -67,11 +67,11 @@ if [ ${#MODIFIED_GOV_FILES[@]} -eq 0 ]; then
 else
   echo "Modified governance files: ${MODIFIED_GOV_FILES[*]}"
   # Check if CHANGELOG was also updated
-  if echo "$CHANGED_FILES" | grep -q "^${CHANGELOG_FILE}$"; then
+  if grep -qxF "$CHANGELOG_FILE" <<< "$CHANGED_FILES"; then
     echo "✓ ${CHANGELOG_FILE} was updated alongside governance changes"
   else
     # Also accept RULINGS.md update as changelog equivalent (at any path)
-    if echo "$CHANGED_FILES" | grep -q "RULINGS.md$"; then
+    if grep -qE '(^|/)RULINGS\.md$' <<< "$CHANGED_FILES"; then
       echo "✓ RULINGS.md was updated (accepted as changelog equivalent)"
     else
       PASSED=false

--- a/tests/test-policy-file.sh
+++ b/tests/test-policy-file.sh
@@ -700,6 +700,32 @@ YAML
   pass "terminology excludes when path or basename pattern matches"
 }
 
+test_changelog_preview_handles_large_change_sets_without_broken_pipe() {
+  local tmp repo i
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  init_repo "$repo"
+  write_base_config "$repo" <<'YAML'
+governance_files:
+  - AGENTS.md
+YAML
+  echo "base" > "$repo/README.md"
+  commit_all "$repo" "base"
+
+  for i in $(seq 1 12000); do
+    printf 'change %s\n' "$i" > "$repo/changed-file-${i}-with-a-long-path-segment-to-exercise-the-preview-pipe-buffer-and-reproduce-sigpipe.txt"
+  done
+  commit_all "$repo" "large file set"
+
+  run_script_capture "$repo" "$D1_SCRIPT"
+  if [ "$CODE" -ne 0 ]; then
+    echo "$OUTPUT" >&2
+    fail "D-1 should not fail while previewing large changed file sets"
+  fi
+  assert_contains "$OUTPUT" "No governance files modified in this change"
+  pass "D-1 preview handles large changed file sets without broken pipe"
+}
+
 test_policy_file_loads_forbidden_terms
 test_policy_file_loads_terminology_exclude_patterns_with_config_term_fallback
 test_policy_file_loads_governance_files
@@ -723,5 +749,6 @@ test_d2_exclude_basename_legacy_anywhere
 test_d2_exclude_basename_anchor_anywhere
 test_d2_exclude_no_match
 test_d2_exclude_path_basename_conflict_either_wins
+test_changelog_preview_handles_large_change_sets_without_broken_pipe
 
 echo "All ${PASS_COUNT} policy_file tests passed"


### PR DESCRIPTION
## Summary

Fixes the D-1 CHANGELOG precheck false failure on large pull requests.

The previous implementation used `echo "$CHANGED_FILES" | head -20` under `set -euo pipefail`. When the changed-file list is large, `head` exits after 20 lines and the upstream `echo` can receive SIGPIPE, causing D-1 to fail before it writes `d1-changelog.json`.

## Changes

- Replace the preview pipe with a here-string based `sed -n '1,20p'` preview.
- Replace D-1 `echo ... | grep -q` checks with here-string based matches to avoid the same early-close pipeline class.
- Add a regression test with 12,000 changed files to cover the large diff case observed in `hl-scene-design-system` PR #28.

## Validation

- RED: the new regression test failed before the script fix with `D-1 should not fail while previewing large changed file sets`.
- `bash tests/test-policy-file.sh` -> `All 24 policy_file tests passed`.
- `bash tests/test-d7-d8.sh` -> `All 7 D-7/D-8 tests passed` (existing stderr warnings remain unrelated).
- `bash tests/test-llm-review-provider-router.sh` -> `llm-review provider router tests passed`.
- `git diff --check` passed.
