### PR TITLE
[codex] Fail closed Sentinel LLM and required gate results

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -34,7 +34,7 @@ env:
             description: 'Skip LLM review layer'
             required: false
             default: 'false'
-            type: boolean
+            type: string
     permissions:
       contents: read
       pull-requests: write
@@ -75,7 +75,7 @@ jobs:
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_ANTHROPIC_API_KEY__/$(gha_expr 'secrets.ANTHROPIC_API_KEY')}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_AUTH_TOKEN__/$(gha_expr 'secrets.HEIYUCODE_AUTH_TOKEN')}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_API_KEY__/$(gha_expr 'secrets.HEIYUCODE_API_KEY')}"
-          CANONICAL_BODY="${CANONICAL_BODY//__EXPR_SKIP_LLM__/$(gha_expr "fromJSON(github.event.inputs.skip_llm || 'false')")}"
+          CANONICAL_BODY="${CANONICAL_BODY//__EXPR_SKIP_LLM__/$(gha_expr "github.event.inputs.skip_llm || 'false'")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_BASE_URL__/$(gha_expr "vars.HEIYUCODE_BASE_URL || 'https://www.heiyucode.com'")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_MODEL__/$(gha_expr "vars.HEIYUCODE_MODEL || ''")}"
 

--- a/.github/workflows/cascade-verify.yml
+++ b/.github/workflows/cascade-verify.yml
@@ -100,7 +100,8 @@ jobs:
           echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
 
           if [ -n "$FAILED" ]; then
-            echo "::warning::Some dispatches failed: ${FAILED}"
+            echo "::error::Cascade dispatch failed for: ${FAILED}"
+            exit 1
           fi
 
   collect-results:
@@ -173,8 +174,8 @@ jobs:
           echo "" >> /tmp/cascade-summary.md
           cat /tmp/cascade-report.md >> /tmp/cascade-summary.md
 
-      - name: Create issue if failures detected
-        if: steps.results.outputs.fail != '0'
+      - name: Create issue if failures or incomplete results detected
+        if: steps.results.outputs.fail != '0' || steps.results.outputs.skip != '0'
         env:
           GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
         run: |
@@ -184,7 +185,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/huanlongAI/sentinel-shared/issues" \
             -d "$(jq -n \
-              --arg title "🚨 Cascade Verification: ${{ steps.results.outputs.fail }} repo(s) failed" \
+              --arg title "🚨 Cascade Verification: ${{ steps.results.outputs.fail }} failed, ${{ steps.results.outputs.skip }} skip/pending" \
               --arg body "$BODY" \
               '{title: $title, body: $body, labels: ["cascade-failure"]}')"
 
@@ -192,3 +193,9 @@ jobs:
         run: |
           echo "## Cascade Verification Results" >> $GITHUB_STEP_SUMMARY
           cat /tmp/cascade-summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail on downstream verification gaps
+        if: steps.results.outputs.fail != '0' || steps.results.outputs.skip != '0'
+        run: |
+          echo "::error::Cascade downstream verification failed or incomplete: ${{ steps.results.outputs.fail }} failed, ${{ steps.results.outputs.skip }} skip/pending"
+          exit 1

--- a/.github/workflows/consistency-sentinel.yml
+++ b/.github/workflows/consistency-sentinel.yml
@@ -114,7 +114,12 @@ jobs:
       - name: "聚合判定 & 生成报告"
         id: aggregate
         if: always()
-        run: .sentinel-shared/scripts/aggregate.sh
+        run: |
+          REQUIRED_RESULTS="d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json"
+          if [ "${{ inputs.skip_llm }}" != "true" ]; then
+            REQUIRED_RESULTS="$REQUIRED_RESULTS llm-review.json"
+          fi
+          REQUIRED_RESULT_FILES="$REQUIRED_RESULTS" .sentinel-shared/scripts/aggregate.sh
 
       # ---- PR Comment ----
       - name: "发布报告到 PR"

--- a/.github/workflows/d8-cross-repo-ssot.yml
+++ b/.github/workflows/d8-cross-repo-ssot.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       HAS_PAT_DOWNSTREAM_READ: ${{ secrets.PAT_DOWNSTREAM_READ != '' }}
     steps:
-      - name: Skip D-8 when PAT_DOWNSTREAM_READ is not configured
+      - name: Fail D-8 when PAT_DOWNSTREAM_READ is not configured
         if: env.HAS_PAT_DOWNSTREAM_READ != 'true'
         run: |
           set -euo pipefail
@@ -60,13 +60,14 @@ jobs:
           {
             "check_id": "D-8",
             "check_name": "Cross-Repo SSOT",
-            "passed": true,
-            "status": "skipped_missing_pat",
-            "warnings": ["PAT_DOWNSTREAM_READ is not configured; cross-repo checkout skipped"],
+            "passed": false,
+            "status": "missing_pat",
+            "warnings": ["PAT_DOWNSTREAM_READ is not configured; D-8 cross-repo checkout cannot run"],
             "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           EOF
-          echo "::warning::PAT_DOWNSTREAM_READ is not configured; D-8 cross-repo checkout skipped"
+          echo "::error::PAT_DOWNSTREAM_READ is not configured; D-8 cross-repo checkout cannot run"
+          exit 1
 
       - name: Checkout upstream repository
         if: env.HAS_PAT_DOWNSTREAM_READ == 'true'

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,45 @@
+name: Sentinel Shared Self Test
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".sentinel/checks/**"
+      - "scripts/**"
+      - "tests/**"
+      - "prompts/**"
+      - "matrix/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".sentinel/checks/**"
+      - "scripts/**"
+      - "tests/**"
+      - "prompts/**"
+      - "matrix/**"
+
+permissions:
+  contents: read
+
+jobs:
+  shell-tests:
+    name: Shell Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run shell regression tests
+        run: |
+          bash tests/test-llm-review-provider-router.sh
+          bash tests/test-policy-file.sh
+          bash tests/test-d7-d8.sh
+          bash tests/test-ci-workflow.sh
+
+      - name: Check shell syntax
+        run: bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh
+
+      - name: Check workflow YAML syntax
+        run: |
+          ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'

--- a/.sentinel/checks/d7-reverse-ssot.sh
+++ b/.sentinel/checks/d7-reverse-ssot.sh
@@ -64,12 +64,18 @@ if [ "${#issues[@]}" -gt 0 ]; then
   passed=false
 fi
 
+if [ "${#issues[@]}" -gt 0 ]; then
+  issues_json="$(json_string_array "${issues[@]}")"
+else
+  issues_json="$(json_string_array)"
+fi
+
 cat > "$result_file" <<EOF
 {
   "check_id": "D-7",
   "check_name": "Reverse SSOT",
   "passed": $passed,
-  "issues": $(json_string_array "${issues[@]}"),
+  "issues": $issues_json,
   "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF

--- a/.sentinel/checks/d8-cross-repo-ssot.sh
+++ b/.sentinel/checks/d8-cross-repo-ssot.sh
@@ -75,13 +75,19 @@ write_result() {
   local status="$1"
   shift
   local warnings=("$@")
+  local warnings_json
+  if [ "${#warnings[@]}" -gt 0 ]; then
+    warnings_json="$(json_string_array "${warnings[@]}")"
+  else
+    warnings_json="$(json_string_array)"
+  fi
   cat > "$result_file" <<EOF
 {
   "check_id": "D-8",
   "check_name": "Cross-Repo SSOT",
   "passed": $passed,
   "status": "$status",
-  "warnings": $(json_string_array "${warnings[@]}"),
+  "warnings": $warnings_json,
   "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Consistency Sentinel 共享基础设施 — Reusable Workflows + Scripts + Matri
 
 `scripts/llm-review.sh` 支持以下 provider：
 
-- `auto`：默认值。优先使用 HeiyuCode token；否则回退 Anthropic official；都不存在则跳过 LLM 层。
+- `auto`：默认值。优先使用 HeiyuCode token；否则回退 Anthropic official；都不存在则 fail closed。
 - `anthropic`：使用 Anthropic official Messages API。
 - `heiyucode` / `heiyucode_claude_code`：使用 HeiyuCode Claude Code client transport。
 

--- a/scripts/aggregate.sh
+++ b/scripts/aggregate.sh
@@ -13,8 +13,29 @@ mkdir -p "$RESULTS_DIR"
 echo "Verdict Aggregation"
 echo "Results directory: $RESULTS_DIR"
 
-# Find all d*-*.json files in results directory
-RESULT_FILES=$(find "$RESULTS_DIR" -maxdepth 1 -name "d*-*.json" -type f | sort)
+REQUIRED_RESULT_FILES="${REQUIRED_RESULT_FILES:-d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json}"
+if [ -n "$REQUIRED_RESULT_FILES" ]; then
+  for required_result in $REQUIRED_RESULT_FILES; do
+    [ -z "$required_result" ] && continue
+    if [ ! -f "$RESULTS_DIR/$required_result" ]; then
+      echo "::error::Required sentinel result missing: $required_result"
+      jq -n \
+        --arg file "$required_result" \
+        --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{
+          check_id: "D-MISSING",
+          check_name: "Missing Result",
+          passed: false,
+          status: "missing",
+          issues: ["Required sentinel result file missing: " + $file],
+          timestamp: $timestamp
+        }' > "$RESULTS_DIR/$required_result"
+    fi
+  done
+fi
+
+# Find deterministic check files plus optional LLM review result.
+RESULT_FILES=$(find "$RESULTS_DIR" -maxdepth 1 \( -name "d*-*.json" -o -name "llm-review.json" \) -type f | sort)
 
 if [ -z "$RESULT_FILES" ]; then
   echo "No result files found in $RESULTS_DIR"
@@ -45,8 +66,8 @@ while IFS= read -r result_file; do
   fi
 
   # Parse JSON result
-  check_id=$(jq -r '.check_id // "unknown"' "$result_file" 2>/dev/null || echo "unknown")
-  check_name=$(jq -r '.check_name // "unknown"' "$result_file" 2>/dev/null || echo "unknown")
+  check_id=$(jq -r '.check_id // .review_id // "unknown"' "$result_file" 2>/dev/null || echo "unknown")
+  check_name=$(jq -r '.check_name // (if (.review_id // "") == "llm-review" then "LLM Review" else "unknown" end)' "$result_file" 2>/dev/null || echo "unknown")
   passed=$(jq -r '.passed // false' "$result_file" 2>/dev/null || echo "false")
 
   echo "  Check: $check_id - $check_name"
@@ -60,7 +81,7 @@ while IFS= read -r result_file; do
     FAILED_CHECKS=$((FAILED_CHECKS + 1))
 
     # Extract issues
-    issues=$(jq -r '.issues[]? // .violations[]? // empty' "$result_file" 2>/dev/null || true)
+    issues=$(jq -r '([.issues[]?, .violations[]?] + (if (.reason // "") != "" then [.reason] else [] end))[]?' "$result_file" 2>/dev/null || true)
     while IFS= read -r issue; do
       [ -z "$issue" ] && continue
       ALL_ISSUES+=("[$check_id] $issue")
@@ -147,10 +168,10 @@ REPORT_FILE="$RESULTS_DIR/sentinel-report.md"
   while IFS= read -r result_file; do
     [ -z "$result_file" ] && continue
     [ ! -f "$result_file" ] && continue
-    r_id=$(jq -r '.check_id // "?"' "$result_file" 2>/dev/null || echo "?")
-    r_name=$(jq -r '.check_name // "?"' "$result_file" 2>/dev/null || echo "?")
+    r_id=$(jq -r '.check_id // .review_id // "?"' "$result_file" 2>/dev/null || echo "?")
+    r_name=$(jq -r '.check_name // (if (.review_id // "") == "llm-review" then "LLM Review" else "?" end)' "$result_file" 2>/dev/null || echo "?")
     r_pass=$(jq -r '.passed // false' "$result_file" 2>/dev/null || echo "false")
-    r_issues=$(jq -r '([.issues[]?, .violations[]?] | join("; ")) // ""' "$result_file" 2>/dev/null || echo "")
+    r_issues=$(jq -r '([.issues[]?, .violations[]?] + (if (.reason // "") != "" then [.reason] else [] end) | join("; ")) // ""' "$result_file" 2>/dev/null || echo "")
     if [ "$r_pass" = "true" ]; then
       echo "| ${r_id} ${r_name} | ✅ | — |"
     else

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -86,6 +86,26 @@ write_skip_result() {
 EOF
 }
 
+write_error_result() {
+  local reason="$1"
+  jq -n \
+    --arg provider "$LLM_PROVIDER" \
+    --arg model "$LLM_MODEL" \
+    --arg reason "$reason" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      review_id: "llm-review",
+      check_name: "LLM Review",
+      provider: $provider,
+      model: $model,
+      status: "error",
+      reason: $reason,
+      passed: false,
+      escalate: true,
+      timestamp: $timestamp
+    }' > "$RESULTS_DIR/llm-review.json"
+}
+
 # --- Read LLM configuration (nested under llm:) ---
 LLM_MODEL=$(yaml_get_nested "$CONFIG_FILE" "llm" "model" "claude-opus-4-6")
 LLM_MAX_TOKENS=$(yaml_get_nested "$CONFIG_FILE" "llm" "max_output_tokens" "8192")
@@ -129,15 +149,15 @@ fi
 echo "Config: provider=$LLM_PROVIDER model=$LLM_MODEL max_tokens=$LLM_MAX_TOKENS threshold=$CONFIDENCE_THRESHOLD"
 
 if [ "$LLM_PROVIDER" = "unsupported" ]; then
-  echo "::warning::Unsupported LLM provider '$REQUESTED_PROVIDER' — skipping LLM review"
-  write_skip_result "Unsupported LLM provider: ${REQUESTED_PROVIDER}"
-  exit 0
+  echo "::error::Unsupported LLM provider '$REQUESTED_PROVIDER' — fail closed"
+  write_error_result "Unsupported LLM provider: ${REQUESTED_PROVIDER}"
+  exit 1
 fi
 
 if [ "$LLM_PROVIDER" = "none" ]; then
-  echo "::warning::No LLM provider credentials configured — skipping LLM review"
-  write_skip_result "No LLM provider credentials configured"
-  exit 0
+  echo "::error::No LLM provider credentials configured — fail closed"
+  write_error_result "No LLM provider credentials configured"
+  exit 1
 fi
 
 if [ -z "$LLM_CHECKS" ]; then
@@ -262,9 +282,9 @@ USER_JSON=$(echo "$USER_MSG" | jq -Rsa .)
 RESPONSE_TEXT=""
 if [ "$LLM_PROVIDER" = "anthropic" ]; then
   if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "::warning::ANTHROPIC_API_KEY not set — skipping LLM review"
-    write_skip_result "ANTHROPIC_API_KEY not configured"
-    exit 0
+    echo "::error::ANTHROPIC_API_KEY not set — fail closed"
+    write_error_result "ANTHROPIC_API_KEY not configured"
+    exit 1
   fi
 
   API_RESPONSE=$(curl -s --max-time 120 \
@@ -280,38 +300,32 @@ if [ "$LLM_PROVIDER" = "anthropic" ]; then
     "https://api.anthropic.com/v1/messages" 2>&1) || true
 
   if [ -z "$API_RESPONSE" ]; then
-    echo "::warning::Claude API returned empty response — ESCALATE"
-    cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"Empty API response","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-    exit 0
+    echo "::error::Claude API returned empty response — fail closed"
+    write_error_result "Empty API response"
+    exit 1
   fi
 
   API_ERROR=$(echo "$API_RESPONSE" | jq -r '.error.message // empty' 2>/dev/null || true)
   if [ -n "$API_ERROR" ]; then
-    echo "::warning::Claude API error: $API_ERROR — ESCALATE"
-    cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"API error: ${API_ERROR}","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-    exit 0
+    echo "::error::Claude API error: $API_ERROR — fail closed"
+    write_error_result "API error: ${API_ERROR}"
+    exit 1
   fi
 
   RESPONSE_TEXT=$(echo "$API_RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
 elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   if [ -z "$HEIYUCODE_TOKEN" ]; then
-    echo "::warning::HEIYUCODE_AUTH_TOKEN/HEIYUCODE_API_KEY not set — skipping LLM review"
-    write_skip_result "HeiyuCode token not configured"
-    exit 0
+    echo "::error::HEIYUCODE_AUTH_TOKEN/HEIYUCODE_API_KEY not set — fail closed"
+    write_error_result "HeiyuCode token not configured"
+    exit 1
   fi
 
   CLAUDE_BIN="$(command -v claude || true)"
   if [ -z "$CLAUDE_BIN" ]; then
     if ! command -v npm >/dev/null 2>&1; then
-      echo "::warning::npm unavailable and claude CLI not installed — ESCALATE"
-      cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"claude CLI unavailable","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-      exit 0
+      echo "::error::npm unavailable and claude CLI not installed — fail closed"
+      write_error_result "claude CLI unavailable"
+      exit 1
     fi
     npm install --prefix /tmp/sentinel-claude-code-cli --no-save @anthropic-ai/claude-code@1.0.100 >/dev/null
     CLAUDE_BIN="/tmp/sentinel-claude-code-cli/node_modules/.bin/claude"
@@ -327,20 +341,16 @@ ${USER_MSG}"
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
     "$CLAUDE_BIN" -p "$CLAUDE_PROMPT" --output-format text --model "$LLM_MODEL" 2>"$CLAUDE_ERR"); then
     CLAUDE_ERROR=$(cat "$CLAUDE_ERR")
-    echo "::warning::HeiyuCode Claude Code client error: $CLAUDE_ERROR — ESCALATE"
-    cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"HeiyuCode Claude Code client error","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-    exit 0
+    echo "::error::HeiyuCode Claude Code client error: $CLAUDE_ERROR — fail closed"
+    write_error_result "HeiyuCode Claude Code client error"
+    exit 1
   fi
 fi
 
 if [ -z "$RESPONSE_TEXT" ]; then
-  echo "::warning::No text in provider response — ESCALATE"
-  cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"No text in response","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-  exit 0
+  echo "::error::No text in provider response — fail closed"
+  write_error_result "No text in response"
+  exit 1
 fi
 
 echo "Response received (${#RESPONSE_TEXT} chars)"
@@ -364,12 +374,13 @@ if echo "$REVIEW_JSON" | jq . >/dev/null 2>&1; then
   echo "Summary: $SUMMARY"
   echo "$REVIEW_JSON" | jq -r '.checks // {} | to_entries[] | "  \(.key): \(.value.verdict) (confidence: \(.value.confidence // "N/A"))"' 2>/dev/null || true
 
-  if [ "$VERDICT" = "FAIL" ]; then
+  if [ "$VERDICT" = "FAIL" ] || [ "$VERDICT" = "ESCALATE" ]; then
     PASSED=false
   fi
 else
-  echo "::warning::Could not parse LLM JSON — ESCALATE"
-  REVIEW_JSON="{}"
+  echo "::error::Could not parse LLM JSON — fail closed"
+  write_error_result "Could not parse LLM JSON"
+  exit 1
 fi
 
 # --- Write result ---

--- a/tests/test-ci-workflow.sh
+++ b/tests/test-ci-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/self-test.yml"
 CALLER_SYNC="$ROOT_DIR/.github/workflows/caller-sync.yml"
+CASCADE_VERIFY="$ROOT_DIR/.github/workflows/cascade-verify.yml"
 README="$ROOT_DIR/README.md"
 
 fail() {
@@ -30,6 +31,9 @@ assert_file_contains "$WORKFLOW" "bash -n scripts/*.sh tests/*.sh .sentinel/chec
 assert_file_contains "$WORKFLOW" "YAML.load_file"
 assert_file_contains "$CALLER_SYNC" "type: string"
 assert_file_contains "$CALLER_SYNC" "github.event.inputs.skip_llm || 'false'"
+assert_file_contains "$CASCADE_VERIFY" "::error::Cascade dispatch failed"
+assert_file_contains "$CASCADE_VERIFY" "::error::Cascade downstream verification failed or incomplete"
+assert_file_contains "$CASCADE_VERIFY" "steps.results.outputs.skip != '0'"
 assert_file_contains "$README" "都不存在则 fail closed"
 
 echo "ci workflow tests passed"

--- a/tests/test-ci-workflow.sh
+++ b/tests/test-ci-workflow.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/self-test.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  if [ ! -f "$file" ]; then
+    fail "Expected file to exist: $file"
+  fi
+  if ! grep -Fq "$needle" "$file"; then
+    fail "Expected $file to contain: $needle"
+  fi
+}
+
+assert_file_contains "$WORKFLOW" "pull_request:"
+assert_file_contains "$WORKFLOW" "bash tests/test-llm-review-provider-router.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-policy-file.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-d7-d8.sh"
+assert_file_contains "$WORKFLOW" "bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh"
+assert_file_contains "$WORKFLOW" "YAML.load_file"
+
+echo "ci workflow tests passed"

--- a/tests/test-ci-workflow.sh
+++ b/tests/test-ci-workflow.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/self-test.yml"
+CALLER_SYNC="$ROOT_DIR/.github/workflows/caller-sync.yml"
+README="$ROOT_DIR/README.md"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -26,5 +28,8 @@ assert_file_contains "$WORKFLOW" "bash tests/test-policy-file.sh"
 assert_file_contains "$WORKFLOW" "bash tests/test-d7-d8.sh"
 assert_file_contains "$WORKFLOW" "bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh"
 assert_file_contains "$WORKFLOW" "YAML.load_file"
+assert_file_contains "$CALLER_SYNC" "type: string"
+assert_file_contains "$CALLER_SYNC" "github.event.inputs.skip_llm || 'false'"
+assert_file_contains "$README" "都不存在则 fail closed"
 
 echo "ci workflow tests passed"

--- a/tests/test-d7-d8.sh
+++ b/tests/test-d7-d8.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 D7_SCRIPT="$ROOT_DIR/.sentinel/checks/d7-reverse-ssot.sh"
 D8_SCRIPT="$ROOT_DIR/.sentinel/checks/d8-cross-repo-ssot.sh"
+D8_WORKFLOW="$ROOT_DIR/.github/workflows/d8-cross-repo-ssot.yml"
 
 PASS_COUNT=0
 
@@ -18,9 +19,32 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "Expected output not to contain: $needle"
+    echo "Actual output:"
+    echo "$haystack"
+    exit 1
+  fi
+}
+
 pass() {
   PASS_COUNT=$((PASS_COUNT + 1))
   echo "ok - $1"
+}
+
+test_d8_workflow_missing_pat_fails_closed() {
+  local workflow
+  workflow="$(cat "$D8_WORKFLOW")"
+  if [[ "$workflow" == *'"status": "skipped_missing_pat"'* && "$workflow" == *'"passed": true'* ]]; then
+    echo "D-8 workflow must not pass when PAT_DOWNSTREAM_READ is missing"
+    exit 1
+  fi
+  assert_contains "$workflow" '"passed": false'
+  assert_contains "$workflow" "PAT_DOWNSTREAM_READ is not configured; D-8 cross-repo checkout cannot run"
+  pass "D-8 workflow fails closed when PAT_DOWNSTREAM_READ is missing"
 }
 
 make_guanghe_docs() {
@@ -98,10 +122,13 @@ TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 # D-7 pass.
+test_d8_workflow_missing_pat_fails_closed
+
 D7_PASS_DIR="$TMP_ROOT/d7-pass"
 make_guanghe_docs "$D7_PASS_DIR" "0.6.0-alpha" "0.6.0-alpha"
-(cd "$D7_PASS_DIR" && RESULTS_DIR="$TMP_ROOT/results-d7-pass" "$D7_SCRIPT") >/tmp/d7-pass.out
-assert_contains "$(cat /tmp/d7-pass.out)" "PASS: D-7 reverse SSOT consistent at 0.6.0-alpha"
+D7_PASS_OUTPUT=$(cd "$D7_PASS_DIR" && RESULTS_DIR="$TMP_ROOT/results-d7-pass" "$D7_SCRIPT" 2>&1)
+assert_contains "$D7_PASS_OUTPUT" "PASS: D-7 reverse SSOT consistent at 0.6.0-alpha"
+assert_not_contains "$D7_PASS_OUTPUT" "unbound variable"
 pass "D-7 accepts matching README and CLAUDE-CONTEXT versions"
 
 # D-7 drift blocks.
@@ -124,8 +151,9 @@ UPSTREAM_DIR="$TMP_ROOT/upstream"
 D8_CURRENT_DIR="$TMP_ROOT/d8-current"
 make_upstream "$UPSTREAM_DIR"
 make_downstream_semver "$D8_CURRENT_DIR" "0.6.0-alpha"
-D8_CURRENT_OUTPUT=$(UPSTREAM_DIR="$UPSTREAM_DIR" DOWNSTREAM_DIR="$D8_CURRENT_DIR" RESULTS_DIR="$TMP_ROOT/results-d8-current" "$D8_SCRIPT")
+D8_CURRENT_OUTPUT=$(UPSTREAM_DIR="$UPSTREAM_DIR" DOWNSTREAM_DIR="$D8_CURRENT_DIR" RESULTS_DIR="$TMP_ROOT/results-d8-current" "$D8_SCRIPT" 2>&1)
 assert_contains "$D8_CURRENT_OUTPUT" "PASS: D-8 downstream pin 0.6.0-alpha is within allowed drift"
+assert_not_contains "$D8_CURRENT_OUTPUT" "unbound variable"
 pass "D-8 accepts current semver pin"
 
 # D-8 old semver emits WARN but does not block.

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -103,7 +103,132 @@ SH
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "HeiyuCode result metadata mismatch"
 }
 
+test_anthropic_api_error_fails_closed() {
+  local tmp fake_bin calls output code
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+cat <<'JSON'
+{"error":{"message":"Your credit balance is too low to access the Anthropic API."}}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  set +e
+  output=$(
+    cd "$tmp/repo" && \
+      PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh" 2>&1
+  )
+  code=$?
+  set -e
+
+  if [ "$code" -eq 0 ]; then
+    echo "$output" >&2
+    fail "Anthropic API errors must fail closed"
+  fi
+  jq -e '.provider == "anthropic" and .status == "error" and .passed == false and .escalate == true' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Anthropic API error result must be failing"
+}
+
+test_anthropic_empty_text_fails_closed() {
+  local tmp fake_bin calls output code
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+cat <<'JSON'
+{"content":[{"text":""}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  set +e
+  output=$(
+    cd "$tmp/repo" && \
+      PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh" 2>&1
+  )
+  code=$?
+  set -e
+
+  if [ "$code" -eq 0 ]; then
+    echo "$output" >&2
+    fail "Empty provider text must fail closed"
+  fi
+  jq -e '.provider == "anthropic" and .status == "error" and .passed == false and .escalate == true' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty response result must be failing"
+}
+
+test_aggregate_includes_llm_review_failure() {
+  local tmp output code
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/results"
+  cat > "$tmp/results/d1-changelog.json" <<'JSON'
+{"check_id":"D-1","check_name":"CHANGELOG","passed":true,"issues":[]}
+JSON
+  cat > "$tmp/results/llm-review.json" <<'JSON'
+{"review_id":"llm-review","check_name":"LLM Review","provider":"anthropic","status":"error","reason":"API error","passed":false,"escalate":true}
+JSON
+
+  set +e
+  output=$(RESULTS_DIR="$tmp/results" REQUIRED_RESULT_FILES="d1-changelog.json" "$ROOT_DIR/scripts/aggregate.sh" 2>&1)
+  code=$?
+  set -e
+
+  if [ "$code" -eq 0 ]; then
+    echo "$output" >&2
+    fail "Aggregator must fail when llm-review.json failed"
+  fi
+  jq -e '.verdict.total_checks == 2 and .verdict.failed == 1 and (.results[] | select(.review_id == "llm-review" and .passed == false))' \
+    "$tmp/results/aggregate.json" >/dev/null || fail "Aggregator must include failed llm-review result"
+}
+
+test_aggregate_fails_closed_when_required_result_is_missing() {
+  local tmp output code
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/results"
+  cat > "$tmp/results/d1-changelog.json" <<'JSON'
+{"check_id":"D-1","check_name":"CHANGELOG","passed":true,"issues":[]}
+JSON
+
+  set +e
+  output=$(RESULTS_DIR="$tmp/results" REQUIRED_RESULT_FILES="d1-changelog.json d2-terminology.json" "$ROOT_DIR/scripts/aggregate.sh" 2>&1)
+  code=$?
+  set -e
+
+  if [ "$code" -eq 0 ]; then
+    echo "$output" >&2
+    fail "Aggregator must fail when a required result file is missing"
+  fi
+  jq -e '.verdict.failed == 1 and (.results[] | select(.check_id == "D-MISSING" and .passed == false and (.issues[] | contains("d2-terminology.json"))))' \
+    "$tmp/results/aggregate.json" >/dev/null || fail "Aggregator must materialize missing required result failure"
+}
+
 test_anthropic_provider_uses_messages_api
 test_heiyucode_provider_uses_claude_code_client
+test_anthropic_api_error_fails_closed
+test_anthropic_empty_text_fails_closed
+test_aggregate_includes_llm_review_failure
+test_aggregate_fails_closed_when_required_result_is_missing
 
 echo "llm-review provider router tests passed"

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -8,6 +8,14 @@ fail() {
   exit 1
 }
 
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "Expected output to contain: $needle"
+  fi
+}
+
 make_repo() {
   local dir="$1"
   mkdir -p "$dir/.sentinel/results" "$dir/.sentinel/prompts"
@@ -224,11 +232,20 @@ JSON
     "$tmp/results/aggregate.json" >/dev/null || fail "Aggregator must materialize missing required result failure"
 }
 
+test_workflow_requires_llm_result_when_llm_enabled() {
+  local workflow
+  workflow="$(cat "$ROOT_DIR/.github/workflows/consistency-sentinel.yml")"
+  assert_contains "$workflow" "REQUIRED_RESULT_FILES="
+  assert_contains "$workflow" "llm-review.json"
+  assert_contains "$workflow" "inputs.skip_llm"
+}
+
 test_anthropic_provider_uses_messages_api
 test_heiyucode_provider_uses_claude_code_client
 test_anthropic_api_error_fails_closed
 test_anthropic_empty_text_fails_closed
 test_aggregate_includes_llm_review_failure
 test_aggregate_fails_closed_when_required_result_is_missing
+test_workflow_requires_llm_result_when_llm_enabled
 
 echo "llm-review provider router tests passed"


### PR DESCRIPTION
## What Changed

This fixes the Sentinel fail-open path that made some green `consistency-sentinel` runs look stronger than they were.

Root cause:
- `scripts/llm-review.sh` wrote `passed: true` for provider/API failures and `ESCALATE` cases.
- `scripts/aggregate.sh` only aggregated `d*-*.json`, so `llm-review.json` was ignored even when it existed.
- required deterministic result files could be absent after a crashed `continue-on-error` step without becoming a hard failure.
- the reusable workflow did not require `llm-review.json` when LLM review was enabled.
- D-8 missing `PAT_DOWNSTREAM_READ` was recorded as a passing skip.
- sentinel-shared PRs had no secret-free self-test workflow, so reusable gate changes were only locally validated before merge review.
- caller-sync/docs still described the old LLM skip semantics and a boolean `skip_llm` caller template, drifting from the reusable workflow contract.
- cascade verification treated fan-out dispatch failures and downstream failed/skip results as warning/issue-only, so hub changes could appear green while downstream verification was incomplete.

Changes:
- LLM provider/config/API/client/parse failures now write a failing `llm-review.json` and exit non-zero.
- LLM `ESCALATE` verdict now fails closed instead of passing.
- aggregate now includes `llm-review.json`, reports `.reason`, and materializes missing required D1-D6 result files as failures.
- reusable `consistency-sentinel` now requires `llm-review.json` when `skip_llm != true`.
- D-8 missing `PAT_DOWNSTREAM_READ` now fails closed.
- D-7/D-8 empty array handling no longer emits `unbound variable` noise under `set -u`.
- added a secret-free `Sentinel Shared Self Test` PR workflow that runs shell regressions, shell syntax checks, and workflow YAML parsing.
- aligned caller-sync canonical `skip_llm` with the reusable workflow string input and updated README to document fail-closed auto provider behavior.
- cascade verification now fails when dispatch fan-out fails, when downstream verification fails, or when downstream results are skip/pending after the wait window.

## Impact

After this lands, a green Sentinel required check means deterministic Sentinel outputs are present and passing, and any enabled LLM review must have produced a passing result. Older green Sentinel runs before this fix should not be interpreted as proof that the LLM semantic layer executed successfully.

Future sentinel-shared PRs will also get a lightweight self-test check before merge review. Post-merge cascade verification will fail closed if downstream verification cannot be completed.

## Verification

- `bash tests/test-llm-review-provider-router.sh`
- `bash tests/test-policy-file.sh`
- `bash tests/test-d7-d8.sh`
- `bash tests/test-ci-workflow.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'`
- `git diff --check`

## Boundaries

- No caller repository branch protection changes.
- No PR merge performed.
- Advisory/non-required automation workflows were inspected but not converted to hard gates.
