### PR TITLE
fix(sentinel): timeout HeiyuCode Claude client

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -86,6 +86,117 @@ write_skip_result() {
 EOF
 }
 
+file_size_bytes() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    wc -c < "$file" 2>/dev/null | tr -d ' ' || echo 0
+  else
+    echo 0
+  fi
+}
+
+safe_stderr_tail() {
+  local file="$1"
+  if [ ! -s "$file" ]; then
+    return 0
+  fi
+
+  tail -c 4000 "$file" | HEIYUCODE_TOKEN="${HEIYUCODE_TOKEN:-}" perl -0pe '
+    BEGIN { $secret = $ENV{"HEIYUCODE_TOKEN"} // "" }
+    if ($secret ne "") { s/\Q$secret\E/[redacted]/g }
+  ' 2>/dev/null || printf '<stderr redaction failed>'
+}
+
+write_provider_error_result() {
+  local reason="$1"
+  local exit_code="$2"
+  local duration_seconds="$3"
+  local stdout_file="$4"
+  local stderr_file="$5"
+  local stdout_bytes stderr_bytes stderr_tail base_url_configured timestamp
+
+  stdout_bytes="$(file_size_bytes "$stdout_file")"
+  stderr_bytes="$(file_size_bytes "$stderr_file")"
+  stderr_tail="$(safe_stderr_tail "$stderr_file")"
+  base_url_configured=false
+  if [ -n "${HEIYUCODE_BASE_URL:-}" ]; then
+    base_url_configured=true
+  fi
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  jq -n \
+    --arg provider "$LLM_PROVIDER" \
+    --arg model "$LLM_MODEL" \
+    --arg status "error" \
+    --arg error_type "provider_error" \
+    --arg reason "$reason" \
+    --arg stderr_tail "$stderr_tail" \
+    --arg timestamp "$timestamp" \
+    --argjson exit_code "$exit_code" \
+    --argjson duration_seconds "$duration_seconds" \
+    --argjson stdout_bytes "$stdout_bytes" \
+    --argjson stderr_bytes "$stderr_bytes" \
+    --argjson base_url_configured "$base_url_configured" \
+    '{
+      review_id: "llm-review",
+      provider: $provider,
+      model: $model,
+      status: $status,
+      error_type: $error_type,
+      reason: $reason,
+      passed: true,
+      escalate: true,
+      exit_code: $exit_code,
+      duration_seconds: $duration_seconds,
+      stdout_bytes: $stdout_bytes,
+      stderr_bytes: $stderr_bytes,
+      stderr_tail: $stderr_tail,
+      base_url_configured: $base_url_configured,
+      timestamp: $timestamp
+    }' > "$RESULTS_DIR/llm-review.json"
+
+  echo "::warning::${reason} — ESCALATE (provider=${LLM_PROVIDER} model=${LLM_MODEL} exit_code=${exit_code} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured})"
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+
+  local timeout_marker cmd_pid watchdog_pid status
+  timeout_marker="$(mktemp)"
+  rm -f "$timeout_marker"
+  : > "$stdout_file"
+  : > "$stderr_file"
+
+  set +e
+  "$@" >"$stdout_file" 2>"$stderr_file" &
+  cmd_pid="$!"
+  (
+    sleep "$timeout_seconds"
+    if kill -0 "$cmd_pid" 2>/dev/null; then
+      printf '1\n' > "$timeout_marker"
+      kill -TERM "$cmd_pid" 2>/dev/null || true
+      sleep 1
+      kill -KILL "$cmd_pid" 2>/dev/null || true
+    fi
+  ) &
+  watchdog_pid="$!"
+
+  wait "$cmd_pid" 2>/dev/null
+  status="$?"
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  if [ -f "$timeout_marker" ]; then
+    rm -f "$timeout_marker"
+    return 124
+  fi
+  rm -f "$timeout_marker"
+  return "$status"
+}
+
 # --- Read LLM configuration (nested under llm:) ---
 LLM_MODEL=$(yaml_get_nested "$CONFIG_FILE" "llm" "model" "claude-opus-4-6")
 LLM_MAX_TOKENS=$(yaml_get_nested "$CONFIG_FILE" "llm" "max_output_tokens" "8192")
@@ -96,6 +207,8 @@ REQUESTED_PROVIDER="${SENTINEL_LLM_PROVIDER:-$CONFIG_PROVIDER}"
 HEIYUCODE_BASE_URL="${HEIYUCODE_BASE_URL:-$(yaml_get_nested "$CONFIG_FILE" "llm" "heiyucode_base_url" "https://www.heiyucode.com")}"
 HEIYUCODE_MODEL="${HEIYUCODE_MODEL:-$(yaml_get_nested "$CONFIG_FILE" "llm" "heiyucode_model" "$LLM_MODEL")}"
 HEIYUCODE_TOKEN="${HEIYUCODE_AUTH_TOKEN:-${HEIYUCODE_API_KEY:-}}"
+HEIYUCODE_CLIENT_TIMEOUT_SECONDS="${HEIYUCODE_CLIENT_TIMEOUT_SECONDS:-420}"
+HEIYUCODE_INSTALL_TIMEOUT_SECONDS="${HEIYUCODE_INSTALL_TIMEOUT_SECONDS:-120}"
 
 resolve_provider() {
   local requested="$1"
@@ -299,40 +412,83 @@ EOF
   RESPONSE_TEXT=$(echo "$API_RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
 elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   if [ -z "$HEIYUCODE_TOKEN" ]; then
-    echo "::warning::HEIYUCODE_AUTH_TOKEN/HEIYUCODE_API_KEY not set — skipping LLM review"
-    write_skip_result "HeiyuCode token not configured"
+    write_provider_error_result "HeiyuCode token not configured" 0 0 /dev/null /dev/null
     exit 0
+  fi
+
+  if ! [[ "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [ "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" -lt 1 ]; then
+    HEIYUCODE_CLIENT_TIMEOUT_SECONDS=420
+  fi
+  if ! [[ "$HEIYUCODE_INSTALL_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [ "$HEIYUCODE_INSTALL_TIMEOUT_SECONDS" -lt 1 ]; then
+    HEIYUCODE_INSTALL_TIMEOUT_SECONDS=120
   fi
 
   CLAUDE_BIN="$(command -v claude || true)"
   if [ -z "$CLAUDE_BIN" ]; then
     if ! command -v npm >/dev/null 2>&1; then
-      echo "::warning::npm unavailable and claude CLI not installed — ESCALATE"
-      cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"claude CLI unavailable","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
+      write_provider_error_result "claude CLI unavailable" 127 0 /dev/null /dev/null
       exit 0
     fi
-    npm install --prefix /tmp/sentinel-claude-code-cli --no-save @anthropic-ai/claude-code@1.0.100 >/dev/null
+
+    NPM_OUT="$(mktemp)"
+    NPM_ERR="$(mktemp)"
+    install_started="$(date +%s)"
+    set +e
+    run_with_timeout "$HEIYUCODE_INSTALL_TIMEOUT_SECONDS" "$NPM_OUT" "$NPM_ERR" \
+      npm install --prefix /tmp/sentinel-claude-code-cli --no-save @anthropic-ai/claude-code@1.0.100
+    install_status="$?"
+    set -e
+    if [ "$install_status" -ne 0 ]; then
+      install_duration="$(( $(date +%s) - install_started ))"
+      if [ "$install_status" -eq 124 ]; then
+        write_provider_error_result "Claude Code client install timeout after ${HEIYUCODE_INSTALL_TIMEOUT_SECONDS}s" 124 "$install_duration" "$NPM_OUT" "$NPM_ERR"
+      else
+        write_provider_error_result "Claude Code client install failed" "$install_status" "$install_duration" "$NPM_OUT" "$NPM_ERR"
+      fi
+      exit 0
+    fi
     CLAUDE_BIN="/tmp/sentinel-claude-code-cli/node_modules/.bin/claude"
   fi
 
   CLAUDE_PROMPT="${SYSTEM_PROMPT_CONTENT}
 
 ${USER_MSG}"
+  CLAUDE_OUT="$(mktemp)"
   CLAUDE_ERR="$(mktemp)"
-  if ! RESPONSE_TEXT=$(ANTHROPIC_AUTH_TOKEN="$HEIYUCODE_TOKEN" \
-    ANTHROPIC_BASE_URL="$HEIYUCODE_BASE_URL" \
-    ANTHROPIC_MODEL="$LLM_MODEL" \
-    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-    "$CLAUDE_BIN" -p "$CLAUDE_PROMPT" --output-format text --model "$LLM_MODEL" 2>"$CLAUDE_ERR"); then
-    CLAUDE_ERROR=$(cat "$CLAUDE_ERR")
-    echo "::warning::HeiyuCode Claude Code client error: $CLAUDE_ERROR — ESCALATE"
-    cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"HeiyuCode Claude Code client error","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
+  client_started="$(date +%s)"
+  heiyucode_base_url_configured=false
+  if [ -n "$HEIYUCODE_BASE_URL" ]; then
+    heiyucode_base_url_configured=true
+  fi
+  echo "HeiyuCode Claude Code client timeout_seconds=${HEIYUCODE_CLIENT_TIMEOUT_SECONDS} base_url_configured=${heiyucode_base_url_configured}"
+
+  set +e
+  run_with_timeout "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" "$CLAUDE_OUT" "$CLAUDE_ERR" \
+    env \
+      ANTHROPIC_AUTH_TOKEN="$HEIYUCODE_TOKEN" \
+      ANTHROPIC_BASE_URL="$HEIYUCODE_BASE_URL" \
+      ANTHROPIC_MODEL="$LLM_MODEL" \
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+      "$CLAUDE_BIN" -p "$CLAUDE_PROMPT" --output-format text --model "$LLM_MODEL"
+  client_status="$?"
+  set -e
+  client_duration="$(( $(date +%s) - client_started ))"
+
+  if [ "$client_status" -eq 124 ]; then
+    write_provider_error_result "HeiyuCode Claude Code client timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$CLAUDE_OUT" "$CLAUDE_ERR"
     exit 0
   fi
+  if [ "$client_status" -ne 0 ]; then
+    write_provider_error_result "HeiyuCode Claude Code client error" "$client_status" "$client_duration" "$CLAUDE_OUT" "$CLAUDE_ERR"
+    exit 0
+  fi
+
+  if [ ! -s "$CLAUDE_OUT" ]; then
+    write_provider_error_result "No text in response" 0 "$client_duration" "$CLAUDE_OUT" "$CLAUDE_ERR"
+    exit 0
+  fi
+
+  RESPONSE_TEXT="$(cat "$CLAUDE_OUT")"
 fi
 
 if [ -z "$RESPONSE_TEXT" ]; then

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -181,7 +181,7 @@ run_with_timeout() {
       sleep 1
       kill -KILL "$cmd_pid" 2>/dev/null || true
     fi
-  ) &
+  ) >/dev/null 2>&1 &
   watchdog_pid="$!"
 
   wait "$cmd_pid" 2>/dev/null

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -103,7 +103,187 @@ SH
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "HeiyuCode result metadata mismatch"
 }
 
+test_heiyucode_provider_hard_fails_explicit_fail_verdict() {
+  local tmp fake_bin calls status
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'JSON'
+{"verdict":"FAIL","checks":{"GPC-003":{"verdict":"FAIL","confidence":0.98,"reason":"policy conflict"}},"summary":"fail"}
+JSON
+SH
+  chmod +x "$fake_bin/claude"
+
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+
+  [ "$status" -ne 0 ] || fail "Explicit FAIL verdict should hard fail"
+  jq -e '.provider == "heiyucode_claude_code" and .verdict == "FAIL" and .passed == false' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Explicit FAIL result mismatch"
+}
+
+test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout() {
+  local tmp fake_bin calls status started elapsed
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+sleep 2
+cat <<'JSON'
+{"verdict":"PASS","checks":{"GPC-003":{"verdict":"PASS","confidence":0.96,"reason":"ok"}},"summary":"ok"}
+JSON
+SH
+  chmod +x "$fake_bin/claude"
+
+  started="$(date +%s)"
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      HEIYUCODE_CLIENT_TIMEOUT_SECONDS="1" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+  elapsed="$(( $(date +%s) - started ))"
+
+  [ "$status" -eq 0 ] || fail "Timeout should be non-blocking ESCALATE"
+  [ "$elapsed" -lt 6 ] || fail "Timeout path waited too long: ${elapsed}s"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .status == "error"
+    and .error_type == "provider_error"
+    and (.reason | test("timeout"))
+    and .passed == true
+    and .escalate == true
+    and .exit_code == 124
+    and .duration_seconds >= 1
+    and .base_url_configured == true
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Timeout provider diagnostics mismatch"
+}
+
+test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics() {
+  local tmp fake_bin calls status
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "provider boom" >&2
+exit 17
+SH
+  chmod +x "$fake_bin/claude"
+
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+
+  [ "$status" -eq 0 ] || fail "Provider non-zero exit should be non-blocking ESCALATE"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .model == "claude-heiyu-test"
+    and .status == "error"
+    and .error_type == "provider_error"
+    and .passed == true
+    and .escalate == true
+    and .exit_code == 17
+    and .stdout_bytes == 0
+    and .stderr_bytes > 0
+    and (.stderr_tail | contains("provider boom"))
+    and .base_url_configured == true
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Non-zero provider diagnostics mismatch"
+}
+
+test_heiyucode_provider_empty_output_escalates_with_diagnostics() {
+  local tmp fake_bin calls status
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+SH
+  chmod +x "$fake_bin/claude"
+
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+
+  [ "$status" -eq 0 ] || fail "Empty provider response should be non-blocking ESCALATE"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .status == "error"
+    and .error_type == "provider_error"
+    and .reason == "No text in response"
+    and .passed == true
+    and .escalate == true
+    and .exit_code == 0
+    and .stdout_bytes == 0
+    and .stderr_bytes == 0
+    and .stderr_tail == ""
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty output diagnostics mismatch"
+}
+
 test_anthropic_provider_uses_messages_api
 test_heiyucode_provider_uses_claude_code_client
+test_heiyucode_provider_hard_fails_explicit_fail_verdict
+test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout
+test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics
+test_heiyucode_provider_empty_output_escalates_with_diagnostics
 
 echo "llm-review provider router tests passed"


### PR DESCRIPTION
## 摘要
- 为 HeiyuCode Claude Code client 增加内层 timeout，避免 GitHub Actions 等到 job timeout 才取消
- 将 timeout、非零退出、空输出和缺 token 分类为 provider_error / ESCALATE，并保留 non-blocking 口径
- 诊断输出包含 provider、model、exit_code、duration、stdout/stderr 字节数、stderr tail 和 base_url 是否配置，不打印 secret value

## 验证
- bash tests/test-llm-review-provider-router.sh
- bash tests/test-policy-file.sh
- bash tests/test-d7-d8.sh
- bash -n scripts/llm-review.sh
- git diff --check