### PR TITLE
fix(sentinel): route HeiyuCode through Messages API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Consistency Sentinel 共享基础设施 — Reusable Workflows + Scripts + Matri
 
 - `auto`：默认值。优先使用 HeiyuCode token；否则回退 Anthropic official；都不存在则跳过 LLM 层。
 - `anthropic`：使用 Anthropic official Messages API。
-- `heiyucode` / `heiyucode_claude_code`：使用 HeiyuCode Claude Code client transport。
+- `heiyucode` / `heiyucode_claude_code`：使用 HeiyuCode Anthropic-compatible Messages API transport。
 
 Reusable workflow inputs：
 
@@ -22,4 +22,4 @@ Reusable workflow secrets：
 - `HEIYUCODE_AUTH_TOKEN`
 - `HEIYUCODE_API_KEY`
 
-HeiyuCode 路由会优先读取 `HEIYUCODE_AUTH_TOKEN`，再读取 `HEIYUCODE_API_KEY`。
+HeiyuCode 路由会优先读取 `HEIYUCODE_AUTH_TOKEN`，再读取 `HEIYUCODE_API_KEY`。默认先按 `Authorization: Bearer` 调用，若返回 401/403，再用 `x-api-key` 重试一次；日志只记录 header 类型，不输出 secret 值。

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -107,18 +107,31 @@ safe_stderr_tail() {
   ' 2>/dev/null || printf '<stderr redaction failed>'
 }
 
+safe_response_tail() {
+  local file="$1"
+  if [ ! -s "$file" ]; then
+    return 0
+  fi
+
+  tail -c 4000 "$file" | HEIYUCODE_TOKEN="${HEIYUCODE_TOKEN:-}" perl -0pe '
+    BEGIN { $secret = $ENV{"HEIYUCODE_TOKEN"} // "" }
+    if ($secret ne "") { s/\Q$secret\E/[redacted]/g }
+  ' 2>/dev/null || printf '<response redaction failed>'
+}
+
 write_provider_error_result() {
   local reason="$1"
   local exit_code="$2"
   local duration_seconds="$3"
   local stdout_file="$4"
   local stderr_file="$5"
-  local stdout_bytes stderr_bytes stderr_tail base_url_configured api_url_configured timestamp
+  local stdout_bytes stderr_bytes stderr_tail response_tail base_url_configured api_url_configured timestamp
   local provider_transport provider_http_status provider_auth_header_kind
 
   stdout_bytes="$(file_size_bytes "$stdout_file")"
   stderr_bytes="$(file_size_bytes "$stderr_file")"
   stderr_tail="$(safe_stderr_tail "$stderr_file")"
+  response_tail="$(safe_response_tail "$stdout_file")"
   base_url_configured=false
   if [ -n "${HEIYUCODE_BASE_URL:-}" ]; then
     base_url_configured=true
@@ -142,6 +155,7 @@ write_provider_error_result() {
     --arg http_status "$provider_http_status" \
     --arg auth_header_kind "$provider_auth_header_kind" \
     --arg stderr_tail "$stderr_tail" \
+    --arg response_tail "$response_tail" \
     --arg timestamp "$timestamp" \
     --argjson exit_code "$exit_code" \
     --argjson duration_seconds "$duration_seconds" \
@@ -166,6 +180,7 @@ write_provider_error_result() {
       stdout_bytes: $stdout_bytes,
       stderr_bytes: $stderr_bytes,
       stderr_tail: $stderr_tail,
+      response_tail: $response_tail,
       base_url_configured: $base_url_configured,
       api_url_configured: $api_url_configured,
       timestamp: $timestamp

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -113,7 +113,8 @@ write_provider_error_result() {
   local duration_seconds="$3"
   local stdout_file="$4"
   local stderr_file="$5"
-  local stdout_bytes stderr_bytes stderr_tail base_url_configured timestamp
+  local stdout_bytes stderr_bytes stderr_tail base_url_configured api_url_configured timestamp
+  local provider_transport provider_http_status provider_auth_header_kind
 
   stdout_bytes="$(file_size_bytes "$stdout_file")"
   stderr_bytes="$(file_size_bytes "$stderr_file")"
@@ -122,14 +123,24 @@ write_provider_error_result() {
   if [ -n "${HEIYUCODE_BASE_URL:-}" ]; then
     base_url_configured=true
   fi
+  api_url_configured=false
+  if [ -n "${HEIYUCODE_API_URL:-}" ]; then
+    api_url_configured=true
+  fi
+  provider_transport="${PROVIDER_TRANSPORT:-n/a}"
+  provider_http_status="${PROVIDER_HTTP_STATUS:-n/a}"
+  provider_auth_header_kind="${PROVIDER_AUTH_HEADER_KIND:-n/a}"
   timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   jq -n \
     --arg provider "$LLM_PROVIDER" \
     --arg model "$LLM_MODEL" \
+    --arg transport "$provider_transport" \
     --arg status "error" \
     --arg error_type "provider_error" \
     --arg reason "$reason" \
+    --arg http_status "$provider_http_status" \
+    --arg auth_header_kind "$provider_auth_header_kind" \
     --arg stderr_tail "$stderr_tail" \
     --arg timestamp "$timestamp" \
     --argjson exit_code "$exit_code" \
@@ -137,25 +148,30 @@ write_provider_error_result() {
     --argjson stdout_bytes "$stdout_bytes" \
     --argjson stderr_bytes "$stderr_bytes" \
     --argjson base_url_configured "$base_url_configured" \
+    --argjson api_url_configured "$api_url_configured" \
     '{
       review_id: "llm-review",
       provider: $provider,
       model: $model,
+      transport: $transport,
       status: $status,
       error_type: $error_type,
       reason: $reason,
       passed: true,
       escalate: true,
+      http_status: $http_status,
+      auth_header_kind: $auth_header_kind,
       exit_code: $exit_code,
       duration_seconds: $duration_seconds,
       stdout_bytes: $stdout_bytes,
       stderr_bytes: $stderr_bytes,
       stderr_tail: $stderr_tail,
       base_url_configured: $base_url_configured,
+      api_url_configured: $api_url_configured,
       timestamp: $timestamp
     }' > "$RESULTS_DIR/llm-review.json"
 
-  echo "::warning::${reason} — ESCALATE (provider=${LLM_PROVIDER} model=${LLM_MODEL} exit_code=${exit_code} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured})"
+  echo "::warning::${reason} — ESCALATE (provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${provider_transport} http_status=${provider_http_status} auth_header_kind=${provider_auth_header_kind} exit_code=${exit_code} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured} api_url_configured=${api_url_configured})"
 }
 
 run_with_timeout() {
@@ -205,10 +221,10 @@ CONFIDENCE_THRESHOLD=$(yaml_get_nested "$CONFIG_FILE" "llm" "confidence_threshol
 CONFIG_PROVIDER=$(yaml_get_nested "$CONFIG_FILE" "llm" "provider" "auto")
 REQUESTED_PROVIDER="${SENTINEL_LLM_PROVIDER:-$CONFIG_PROVIDER}"
 HEIYUCODE_BASE_URL="${HEIYUCODE_BASE_URL:-$(yaml_get_nested "$CONFIG_FILE" "llm" "heiyucode_base_url" "https://www.heiyucode.com")}"
+HEIYUCODE_API_URL="${HEIYUCODE_API_URL:-${HEIYUCODE_BASE_URL%/}/v1/messages}"
 HEIYUCODE_MODEL="${HEIYUCODE_MODEL:-$(yaml_get_nested "$CONFIG_FILE" "llm" "heiyucode_model" "$LLM_MODEL")}"
 HEIYUCODE_TOKEN="${HEIYUCODE_AUTH_TOKEN:-${HEIYUCODE_API_KEY:-}}"
 HEIYUCODE_CLIENT_TIMEOUT_SECONDS="${HEIYUCODE_CLIENT_TIMEOUT_SECONDS:-420}"
-HEIYUCODE_INSTALL_TIMEOUT_SECONDS="${HEIYUCODE_INSTALL_TIMEOUT_SECONDS:-120}"
 
 resolve_provider() {
   local requested="$1"
@@ -411,6 +427,10 @@ EOF
 
   RESPONSE_TEXT=$(echo "$API_RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
 elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
+  PROVIDER_TRANSPORT="messages-api"
+  PROVIDER_HTTP_STATUS="n/a"
+  PROVIDER_AUTH_HEADER_KIND="n/a"
+
   if [ -z "$HEIYUCODE_TOKEN" ]; then
     write_provider_error_result "HeiyuCode token not configured" 0 0 /dev/null /dev/null
     exit 0
@@ -419,76 +439,111 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   if ! [[ "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [ "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" -lt 1 ]; then
     HEIYUCODE_CLIENT_TIMEOUT_SECONDS=420
   fi
-  if ! [[ "$HEIYUCODE_INSTALL_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [ "$HEIYUCODE_INSTALL_TIMEOUT_SECONDS" -lt 1 ]; then
-    HEIYUCODE_INSTALL_TIMEOUT_SECONDS=120
-  fi
 
-  CLAUDE_BIN="$(command -v claude || true)"
-  if [ -z "$CLAUDE_BIN" ]; then
-    if ! command -v npm >/dev/null 2>&1; then
-      write_provider_error_result "claude CLI unavailable" 127 0 /dev/null /dev/null
-      exit 0
+  REQUEST_BODY="$(mktemp)"
+  API_RESPONSE="$(mktemp)"
+  API_ERR="$(mktemp)"
+  API_META="$(mktemp)"
+  jq -n \
+    --arg model "$LLM_MODEL" \
+    --argjson max_tokens "$LLM_MAX_TOKENS" \
+    --arg system "$SYSTEM_PROMPT_CONTENT" \
+    --arg user "$USER_MSG" \
+    '{model:$model,max_tokens:$max_tokens,system:$system,messages:[{role:"user",content:$user}]}' \
+    > "$REQUEST_BODY"
+
+  call_heiyucode_messages() {
+    local auth_header_kind="$1"
+    local response_file="$2"
+    local stderr_file="$3"
+    local meta_file="$4"
+    local auth_header
+
+    if [ "$auth_header_kind" = "x-api-key" ]; then
+      auth_header="x-api-key: ${HEIYUCODE_TOKEN}"
+    else
+      auth_header="Authorization: Bearer ${HEIYUCODE_TOKEN}"
     fi
 
-    NPM_OUT="$(mktemp)"
-    NPM_ERR="$(mktemp)"
-    install_started="$(date +%s)"
-    set +e
-    run_with_timeout "$HEIYUCODE_INSTALL_TIMEOUT_SECONDS" "$NPM_OUT" "$NPM_ERR" \
-      npm install --prefix /tmp/sentinel-claude-code-cli --no-save @anthropic-ai/claude-code@1.0.100
-    install_status="$?"
-    set -e
-    if [ "$install_status" -ne 0 ]; then
-      install_duration="$(( $(date +%s) - install_started ))"
-      if [ "$install_status" -eq 124 ]; then
-        write_provider_error_result "Claude Code client install timeout after ${HEIYUCODE_INSTALL_TIMEOUT_SECONDS}s" 124 "$install_duration" "$NPM_OUT" "$NPM_ERR"
-      else
-        write_provider_error_result "Claude Code client install failed" "$install_status" "$install_duration" "$NPM_OUT" "$NPM_ERR"
-      fi
-      exit 0
-    fi
-    CLAUDE_BIN="/tmp/sentinel-claude-code-cli/node_modules/.bin/claude"
-  fi
+    run_with_timeout "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" "$meta_file" "$stderr_file" \
+      curl -sS --max-time "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" \
+        -o "$response_file" \
+        -w "http_status=%{http_code}\ntime_total=%{time_total}\nsize_download=%{size_download}\n" \
+        -X POST "$HEIYUCODE_API_URL" \
+        -H "Content-Type: application/json" \
+        -H "anthropic-version: 2023-06-01" \
+        -H "$auth_header" \
+        --data-binary "@${REQUEST_BODY}"
+  }
 
-  CLAUDE_PROMPT="${SYSTEM_PROMPT_CONTENT}
+  extract_http_status() {
+    local meta_file="$1"
+    awk -F= '/^http_status=/{print $2; exit}' "$meta_file" 2>/dev/null || true
+  }
 
-${USER_MSG}"
-  CLAUDE_OUT="$(mktemp)"
-  CLAUDE_ERR="$(mktemp)"
   client_started="$(date +%s)"
   heiyucode_base_url_configured=false
   if [ -n "$HEIYUCODE_BASE_URL" ]; then
     heiyucode_base_url_configured=true
   fi
-  echo "HeiyuCode Claude Code client timeout_seconds=${HEIYUCODE_CLIENT_TIMEOUT_SECONDS} base_url_configured=${heiyucode_base_url_configured}"
+  echo "HeiyuCode Messages API timeout_seconds=${HEIYUCODE_CLIENT_TIMEOUT_SECONDS} base_url_configured=${heiyucode_base_url_configured}"
 
+  AUTH_HEADER_KIND="authorization_bearer"
+  HTTP_STATUS="n/a"
+  PROVIDER_AUTH_HEADER_KIND="$AUTH_HEADER_KIND"
+  PROVIDER_HTTP_STATUS="$HTTP_STATUS"
   set +e
-  run_with_timeout "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" "$CLAUDE_OUT" "$CLAUDE_ERR" \
-    env \
-      ANTHROPIC_AUTH_TOKEN="$HEIYUCODE_TOKEN" \
-      ANTHROPIC_BASE_URL="$HEIYUCODE_BASE_URL" \
-      ANTHROPIC_MODEL="$LLM_MODEL" \
-      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-      "$CLAUDE_BIN" -p "$CLAUDE_PROMPT" --output-format text --model "$LLM_MODEL"
+  call_heiyucode_messages "$AUTH_HEADER_KIND" "$API_RESPONSE" "$API_ERR" "$API_META"
   client_status="$?"
   set -e
   client_duration="$(( $(date +%s) - client_started ))"
+  HTTP_STATUS="$(extract_http_status "$API_META")"
+  PROVIDER_HTTP_STATUS="$HTTP_STATUS"
+
+  if [ "$client_status" -eq 0 ] && { [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; }; then
+    AUTH_HEADER_KIND="x-api-key"
+    PROVIDER_AUTH_HEADER_KIND="$AUTH_HEADER_KIND"
+    client_started="$(date +%s)"
+    set +e
+    call_heiyucode_messages "$AUTH_HEADER_KIND" "$API_RESPONSE" "$API_ERR" "$API_META"
+    client_status="$?"
+    set -e
+    client_duration="$(( $(date +%s) - client_started ))"
+    HTTP_STATUS="$(extract_http_status "$API_META")"
+    PROVIDER_HTTP_STATUS="$HTTP_STATUS"
+  fi
 
   if [ "$client_status" -eq 124 ]; then
-    write_provider_error_result "HeiyuCode Claude Code client timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$CLAUDE_OUT" "$CLAUDE_ERR"
+    write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE" "$API_ERR"
     exit 0
   fi
   if [ "$client_status" -ne 0 ]; then
-    write_provider_error_result "HeiyuCode Claude Code client error" "$client_status" "$client_duration" "$CLAUDE_OUT" "$CLAUDE_ERR"
+    write_provider_error_result "HeiyuCode Messages API curl error" "$client_status" "$client_duration" "$API_RESPONSE" "$API_ERR"
     exit 0
   fi
 
-  if [ ! -s "$CLAUDE_OUT" ]; then
-    write_provider_error_result "No text in response" 0 "$client_duration" "$CLAUDE_OUT" "$CLAUDE_ERR"
+  if ! [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
+    if [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; then
+      write_provider_error_result "HeiyuCode Messages API auth error HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE" "$API_ERR"
+    else
+      write_provider_error_result "HeiyuCode Messages API HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE" "$API_ERR"
+    fi
     exit 0
   fi
 
-  RESPONSE_TEXT="$(cat "$CLAUDE_OUT")"
+  set +e
+  RESPONSE_TEXT="$(jq -r '[.content[]? | select(.type == "text") | .text] | join("\n\n")' "$API_RESPONSE" 2>"$API_ERR")"
+  parse_status="$?"
+  set -e
+  if [ "$parse_status" -ne 0 ]; then
+    write_provider_error_result "HeiyuCode Messages API returned invalid JSON" "$parse_status" "$client_duration" "$API_RESPONSE" "$API_ERR"
+    exit 0
+  fi
+
+  if [ -z "$RESPONSE_TEXT" ]; then
+    write_provider_error_result "No text in response" 0 "$client_duration" "$API_RESPONSE" "$API_ERR"
+    exit 0
+  fi
 fi
 
 if [ -z "$RESPONSE_TEXT" ]; then
@@ -535,6 +590,9 @@ cat > "$RESULT_FILE" <<EOF
   "review_id": "llm-review",
   "provider": "$LLM_PROVIDER",
   "model": "$LLM_MODEL",
+  "transport": "${PROVIDER_TRANSPORT:-n/a}",
+  "http_status": "${PROVIDER_HTTP_STATUS:-n/a}",
+  "auth_header_kind": "${PROVIDER_AUTH_HEADER_KIND:-n/a}",
   "status": "completed",
   "verdict": "$VERDICT",
   "passed": $([[ "$PASSED" == true ]] && echo "true" || echo "false"),

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -404,6 +404,16 @@ SYSTEM_JSON=$(echo "$SYSTEM_PROMPT_CONTENT" | jq -Rsa .)
 USER_JSON=$(echo "$USER_MSG" | jq -Rsa .)
 
 RESPONSE_TEXT=""
+PROVIDER_TRANSPORT="${PROVIDER_TRANSPORT:-n/a}"
+PROVIDER_HTTP_STATUS="${PROVIDER_HTTP_STATUS:-n/a}"
+PROVIDER_AUTH_HEADER_KIND="${PROVIDER_AUTH_HEADER_KIND:-n/a}"
+PROVIDER_EXIT_CODE="${PROVIDER_EXIT_CODE:-0}"
+PROVIDER_DURATION_SECONDS="${PROVIDER_DURATION_SECONDS:-0}"
+PROVIDER_STDOUT_BYTES="${PROVIDER_STDOUT_BYTES:-0}"
+PROVIDER_STDERR_BYTES="${PROVIDER_STDERR_BYTES:-0}"
+PROVIDER_BASE_URL_CONFIGURED="${PROVIDER_BASE_URL_CONFIGURED:-false}"
+PROVIDER_API_URL_CONFIGURED="${PROVIDER_API_URL_CONFIGURED:-false}"
+
 if [ "$LLM_PROVIDER" = "anthropic" ]; then
   if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
     echo "::warning::ANTHROPIC_API_KEY not set — skipping LLM review"
@@ -501,6 +511,11 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   if [ -n "$HEIYUCODE_BASE_URL" ]; then
     heiyucode_base_url_configured=true
   fi
+  PROVIDER_BASE_URL_CONFIGURED="$heiyucode_base_url_configured"
+  PROVIDER_API_URL_CONFIGURED=false
+  if [ -n "$HEIYUCODE_API_URL" ]; then
+    PROVIDER_API_URL_CONFIGURED=true
+  fi
   echo "HeiyuCode Messages API timeout_seconds=${HEIYUCODE_CLIENT_TIMEOUT_SECONDS} base_url_configured=${heiyucode_base_url_configured}"
 
   AUTH_HEADER_KIND="authorization_bearer"
@@ -514,6 +529,10 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   client_duration="$(( $(date +%s) - client_started ))"
   HTTP_STATUS="$(extract_http_status "$API_META")"
   PROVIDER_HTTP_STATUS="$HTTP_STATUS"
+  PROVIDER_EXIT_CODE="$client_status"
+  PROVIDER_DURATION_SECONDS="$client_duration"
+  PROVIDER_STDOUT_BYTES="$(file_size_bytes "$API_RESPONSE")"
+  PROVIDER_STDERR_BYTES="$(file_size_bytes "$API_ERR")"
 
   if [ "$client_status" -eq 0 ] && { [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; }; then
     AUTH_HEADER_KIND="x-api-key"
@@ -526,6 +545,10 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
     client_duration="$(( $(date +%s) - client_started ))"
     HTTP_STATUS="$(extract_http_status "$API_META")"
     PROVIDER_HTTP_STATUS="$HTTP_STATUS"
+    PROVIDER_EXIT_CODE="$client_status"
+    PROVIDER_DURATION_SECONDS="$client_duration"
+    PROVIDER_STDOUT_BYTES="$(file_size_bytes "$API_RESPONSE")"
+    PROVIDER_STDERR_BYTES="$(file_size_bytes "$API_ERR")"
   fi
 
   if [ "$client_status" -eq 124 ]; then
@@ -570,6 +593,7 @@ EOF
 fi
 
 echo "Response received (${#RESPONSE_TEXT} chars)"
+echo "Provider diagnostics: provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${PROVIDER_TRANSPORT:-n/a} http_status=${PROVIDER_HTTP_STATUS:-n/a} auth_header_kind=${PROVIDER_AUTH_HEADER_KIND:-n/a} exit_code=${PROVIDER_EXIT_CODE:-0} duration_seconds=${PROVIDER_DURATION_SECONDS:-0} stdout_bytes=${PROVIDER_STDOUT_BYTES:-0} stderr_bytes=${PROVIDER_STDERR_BYTES:-0} base_url_configured=${PROVIDER_BASE_URL_CONFIGURED:-false} api_url_configured=${PROVIDER_API_URL_CONFIGURED:-false}"
 
 # Extract JSON from response
 REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/^{/,/^}/p' || true)
@@ -608,6 +632,12 @@ cat > "$RESULT_FILE" <<EOF
   "transport": "${PROVIDER_TRANSPORT:-n/a}",
   "http_status": "${PROVIDER_HTTP_STATUS:-n/a}",
   "auth_header_kind": "${PROVIDER_AUTH_HEADER_KIND:-n/a}",
+  "exit_code": ${PROVIDER_EXIT_CODE:-0},
+  "duration_seconds": ${PROVIDER_DURATION_SECONDS:-0},
+  "stdout_bytes": ${PROVIDER_STDOUT_BYTES:-0},
+  "stderr_bytes": ${PROVIDER_STDERR_BYTES:-0},
+  "base_url_configured": ${PROVIDER_BASE_URL_CONFIGURED:-false},
+  "api_url_configured": ${PROVIDER_API_URL_CONFIGURED:-false},
   "status": "completed",
   "verdict": "$VERDICT",
   "passed": $([[ "$PASSED" == true ]] && echo "true" || echo "false"),

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -126,7 +126,7 @@ write_provider_error_result() {
   local stdout_file="$4"
   local stderr_file="$5"
   local stdout_bytes stderr_bytes stderr_tail response_tail base_url_configured api_url_configured timestamp
-  local provider_transport provider_http_status provider_auth_header_kind
+  local provider_transport provider_http_status provider_auth_header_kind provider_attempts
 
   stdout_bytes="$(file_size_bytes "$stdout_file")"
   stderr_bytes="$(file_size_bytes "$stderr_file")"
@@ -143,6 +143,7 @@ write_provider_error_result() {
   provider_transport="${PROVIDER_TRANSPORT:-n/a}"
   provider_http_status="${PROVIDER_HTTP_STATUS:-n/a}"
   provider_auth_header_kind="${PROVIDER_AUTH_HEADER_KIND:-n/a}"
+  provider_attempts="${PROVIDER_ATTEMPTS:-0}"
   timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   jq -n \
@@ -158,6 +159,7 @@ write_provider_error_result() {
     --arg response_tail "$response_tail" \
     --arg timestamp "$timestamp" \
     --argjson exit_code "$exit_code" \
+    --argjson attempts "$provider_attempts" \
     --argjson duration_seconds "$duration_seconds" \
     --argjson stdout_bytes "$stdout_bytes" \
     --argjson stderr_bytes "$stderr_bytes" \
@@ -176,6 +178,7 @@ write_provider_error_result() {
       http_status: $http_status,
       auth_header_kind: $auth_header_kind,
       exit_code: $exit_code,
+      attempts: $attempts,
       duration_seconds: $duration_seconds,
       stdout_bytes: $stdout_bytes,
       stderr_bytes: $stderr_bytes,
@@ -186,7 +189,7 @@ write_provider_error_result() {
       timestamp: $timestamp
     }' > "$RESULTS_DIR/llm-review.json"
 
-  echo "::warning::${reason} — ESCALATE (provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${provider_transport} http_status=${provider_http_status} auth_header_kind=${provider_auth_header_kind} exit_code=${exit_code} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured} api_url_configured=${api_url_configured})"
+  echo "::warning::${reason} — ESCALATE (provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${provider_transport} http_status=${provider_http_status} auth_header_kind=${provider_auth_header_kind} exit_code=${exit_code} attempts=${provider_attempts} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured} api_url_configured=${api_url_configured})"
 }
 
 run_with_timeout() {
@@ -411,6 +414,7 @@ PROVIDER_EXIT_CODE="${PROVIDER_EXIT_CODE:-0}"
 PROVIDER_DURATION_SECONDS="${PROVIDER_DURATION_SECONDS:-0}"
 PROVIDER_STDOUT_BYTES="${PROVIDER_STDOUT_BYTES:-0}"
 PROVIDER_STDERR_BYTES="${PROVIDER_STDERR_BYTES:-0}"
+PROVIDER_ATTEMPTS="${PROVIDER_ATTEMPTS:-0}"
 PROVIDER_BASE_URL_CONFIGURED="${PROVIDER_BASE_URL_CONFIGURED:-false}"
 PROVIDER_API_URL_CONFIGURED="${PROVIDER_API_URL_CONFIGURED:-false}"
 
@@ -506,6 +510,17 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
     awk -F= '/^http_status=/{print $2; exit}' "$meta_file" 2>/dev/null || true
   }
 
+  is_retryable_http_status() {
+    case "$1" in
+      500|502|503|504|520|522|524)
+        return 0
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  }
+
   client_started="$(date +%s)"
   heiyucode_base_url_configured=false
   if [ -n "$HEIYUCODE_BASE_URL" ]; then
@@ -522,24 +537,12 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   HTTP_STATUS="n/a"
   PROVIDER_AUTH_HEADER_KIND="$AUTH_HEADER_KIND"
   PROVIDER_HTTP_STATUS="$HTTP_STATUS"
-  set +e
-  call_heiyucode_messages "$AUTH_HEADER_KIND" "$API_RESPONSE" "$API_ERR" "$API_META"
-  client_status="$?"
-  set -e
-  client_duration="$(( $(date +%s) - client_started ))"
-  HTTP_STATUS="$(extract_http_status "$API_META")"
-  PROVIDER_HTTP_STATUS="$HTTP_STATUS"
-  PROVIDER_EXIT_CODE="$client_status"
-  PROVIDER_DURATION_SECONDS="$client_duration"
-  PROVIDER_STDOUT_BYTES="$(file_size_bytes "$API_RESPONSE")"
-  PROVIDER_STDERR_BYTES="$(file_size_bytes "$API_ERR")"
 
-  if [ "$client_status" -eq 0 ] && { [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; }; then
-    AUTH_HEADER_KIND="x-api-key"
-    PROVIDER_AUTH_HEADER_KIND="$AUTH_HEADER_KIND"
-    client_started="$(date +%s)"
+  run_heiyucode_attempt() {
+    local auth_header_kind="$1"
+    PROVIDER_ATTEMPTS="$(( ${PROVIDER_ATTEMPTS:-0} + 1 ))"
     set +e
-    call_heiyucode_messages "$AUTH_HEADER_KIND" "$API_RESPONSE" "$API_ERR" "$API_META"
+    call_heiyucode_messages "$auth_header_kind" "$API_RESPONSE" "$API_ERR" "$API_META"
     client_status="$?"
     set -e
     client_duration="$(( $(date +%s) - client_started ))"
@@ -549,7 +552,22 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
     PROVIDER_DURATION_SECONDS="$client_duration"
     PROVIDER_STDOUT_BYTES="$(file_size_bytes "$API_RESPONSE")"
     PROVIDER_STDERR_BYTES="$(file_size_bytes "$API_ERR")"
+  }
+
+  run_heiyucode_attempt "$AUTH_HEADER_KIND"
+
+  if [ "$client_status" -eq 0 ] && { [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; }; then
+    AUTH_HEADER_KIND="x-api-key"
+    PROVIDER_AUTH_HEADER_KIND="$AUTH_HEADER_KIND"
+    run_heiyucode_attempt "$AUTH_HEADER_KIND"
   fi
+
+  retryable_retries=0
+  while [ "$client_status" -eq 0 ] && is_retryable_http_status "$HTTP_STATUS" && [ "$retryable_retries" -lt 1 ]; do
+    retryable_retries="$(( retryable_retries + 1 ))"
+    echo "HeiyuCode Messages API HTTP ${HTTP_STATUS}; retrying once with auth_header_kind=${AUTH_HEADER_KIND}"
+    run_heiyucode_attempt "$AUTH_HEADER_KIND"
+  done
 
   if [ "$client_status" -eq 124 ]; then
     write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE" "$API_ERR"
@@ -593,7 +611,7 @@ EOF
 fi
 
 echo "Response received (${#RESPONSE_TEXT} chars)"
-echo "Provider diagnostics: provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${PROVIDER_TRANSPORT:-n/a} http_status=${PROVIDER_HTTP_STATUS:-n/a} auth_header_kind=${PROVIDER_AUTH_HEADER_KIND:-n/a} exit_code=${PROVIDER_EXIT_CODE:-0} duration_seconds=${PROVIDER_DURATION_SECONDS:-0} stdout_bytes=${PROVIDER_STDOUT_BYTES:-0} stderr_bytes=${PROVIDER_STDERR_BYTES:-0} base_url_configured=${PROVIDER_BASE_URL_CONFIGURED:-false} api_url_configured=${PROVIDER_API_URL_CONFIGURED:-false}"
+echo "Provider diagnostics: provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${PROVIDER_TRANSPORT:-n/a} http_status=${PROVIDER_HTTP_STATUS:-n/a} auth_header_kind=${PROVIDER_AUTH_HEADER_KIND:-n/a} exit_code=${PROVIDER_EXIT_CODE:-0} attempts=${PROVIDER_ATTEMPTS:-0} duration_seconds=${PROVIDER_DURATION_SECONDS:-0} stdout_bytes=${PROVIDER_STDOUT_BYTES:-0} stderr_bytes=${PROVIDER_STDERR_BYTES:-0} base_url_configured=${PROVIDER_BASE_URL_CONFIGURED:-false} api_url_configured=${PROVIDER_API_URL_CONFIGURED:-false}"
 
 # Extract JSON from response
 REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/^{/,/^}/p' || true)
@@ -633,6 +651,7 @@ cat > "$RESULT_FILE" <<EOF
   "http_status": "${PROVIDER_HTTP_STATUS:-n/a}",
   "auth_header_kind": "${PROVIDER_AUTH_HEADER_KIND:-n/a}",
   "exit_code": ${PROVIDER_EXIT_CODE:-0},
+  "attempts": ${PROVIDER_ATTEMPTS:-0},
   "duration_seconds": ${PROVIDER_DURATION_SECONDS:-0},
   "stdout_bytes": ${PROVIDER_STDOUT_BYTES:-0},
   "stderr_bytes": ${PROVIDER_STDERR_BYTES:-0},

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -120,6 +120,9 @@ case "${FAKE_CURL_MODE}" in
   empty)
     write_response 200 ''
     ;;
+  http_500)
+    write_response 500 '{"error":{"message":"upstream unavailable"}}'
+    ;;
   auth_fallback)
     if [ "$count" -eq 1 ]; then
       write_response 401 '{"code":"INVALID_API_KEY","message":"bad auth header"}'
@@ -326,7 +329,46 @@ test_heiyucode_provider_empty_output_escalates_with_diagnostics() {
     and .stdout_bytes == 0
     and .stderr_bytes == 0
     and .stderr_tail == ""
+    and .response_tail == ""
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty output diagnostics mismatch"
+}
+
+test_heiyucode_provider_http_error_escalates_with_response_tail() {
+  local tmp fake_bin calls status
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="http_500" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+
+  [ "$status" -eq 0 ] || fail "HTTP provider error should be non-blocking ESCALATE"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
+    and .status == "error"
+    and .error_type == "provider_error"
+    and .reason == "HeiyuCode Messages API HTTP 500"
+    and .passed == true
+    and .escalate == true
+    and .http_status == "500"
+    and (.response_tail | contains("upstream unavailable"))
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "HTTP error diagnostics mismatch"
 }
 
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
@@ -367,6 +409,7 @@ test_heiyucode_provider_hard_fails_explicit_fail_verdict
 test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout
 test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics
 test_heiyucode_provider_empty_output_escalates_with_diagnostics
+test_heiyucode_provider_http_error_escalates_with_response_tail
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure
 
 echo "llm-review provider router tests passed"

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -167,6 +167,12 @@ test_heiyucode_provider_uses_messages_api() {
     and .transport == "messages-api"
     and .http_status == "200"
     and .auth_header_kind == "authorization_bearer"
+    and .exit_code == 0
+    and .duration_seconds >= 0
+    and .stdout_bytes > 0
+    and .stderr_bytes == 0
+    and .base_url_configured == true
+    and .api_url_configured == true
     and .passed == true
     and .model == "claude-heiyu-test"
   ' \
@@ -399,6 +405,12 @@ test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
     and .transport == "messages-api"
     and .http_status == "200"
     and .auth_header_kind == "x-api-key"
+    and .exit_code == 0
+    and .duration_seconds >= 0
+    and .stdout_bytes > 0
+    and .stderr_bytes == 0
+    and .base_url_configured == true
+    and .api_url_configured == true
     and .passed == true
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "x-api-key fallback result mismatch"
 }

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -123,6 +123,13 @@ case "${FAKE_CURL_MODE}" in
   http_500)
     write_response 500 '{"error":{"message":"upstream unavailable"}}'
     ;;
+  http_524_then_pass)
+    if [ "$count" -eq 1 ]; then
+      write_response 524 'error code: 524'
+    else
+      write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.96,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}'
+    fi
+    ;;
   auth_fallback)
     if [ "$count" -eq 1 ]; then
       write_response 401 '{"code":"INVALID_API_KEY","message":"bad auth header"}'
@@ -171,6 +178,7 @@ test_heiyucode_provider_uses_messages_api() {
     and .duration_seconds >= 0
     and .stdout_bytes > 0
     and .stderr_bytes == 0
+    and .attempts == 1
     and .base_url_configured == true
     and .api_url_configured == true
     and .passed == true
@@ -373,8 +381,40 @@ test_heiyucode_provider_http_error_escalates_with_response_tail() {
     and .passed == true
     and .escalate == true
     and .http_status == "500"
+    and .attempts == 2
     and (.response_tail | contains("upstream unavailable"))
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "HTTP error diagnostics mismatch"
+}
+
+test_heiyucode_provider_retries_retryable_524_once() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="http_524_then_pass" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  [ "$(cat "$calls/curl.count")" = "2" ] || fail "Retryable 524 should be retried exactly once"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
+    and .http_status == "200"
+    and .attempts == 2
+    and .passed == true
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Retryable 524 retry result mismatch"
 }
 
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
@@ -409,6 +449,7 @@ test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
     and .duration_seconds >= 0
     and .stdout_bytes > 0
     and .stderr_bytes == 0
+    and .attempts == 2
     and .base_url_configured == true
     and .api_url_configured == true
     and .passed == true
@@ -422,6 +463,7 @@ test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout
 test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics
 test_heiyucode_provider_empty_output_escalates_with_diagnostics
 test_heiyucode_provider_http_error_escalates_with_response_tail
+test_heiyucode_provider_retries_retryable_524_once
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure
 
 echo "llm-review provider router tests passed"

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -65,7 +65,78 @@ SH
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Anthropic result metadata mismatch"
 }
 
-test_heiyucode_provider_uses_claude_code_client() {
+write_fake_heiyucode_curl() {
+  local curl_path="$1"
+  cat > "$curl_path" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      out="$2"
+      shift 2
+      ;;
+    -H)
+      printf '%s\n' "$2" >> "$FAKE_CALL_DIR/curl.headers"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+count_file="$FAKE_CALL_DIR/curl.count"
+count=0
+if [ -f "$count_file" ]; then
+  count="$(cat "$count_file")"
+fi
+count="$((count + 1))"
+printf '%s\n' "$count" > "$count_file"
+
+write_response() {
+  local status="$1"
+  local body="$2"
+  printf '%s' "$body" > "$out"
+  printf 'http_status=%s\ntime_total=0.01\nsize_download=%s\n' "$status" "$(wc -c < "$out" | tr -d ' ')"
+}
+
+case "${FAKE_CURL_MODE}" in
+  pass)
+    write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.96,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}'
+    ;;
+  fail)
+    write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"FAIL\",\"checks\":{\"GPC-003\":{\"verdict\":\"FAIL\",\"confidence\":0.98,\"reason\":\"policy conflict\"}},\"summary\":\"fail\"}"}]}'
+    ;;
+  sleep)
+    sleep 2
+    ;;
+  nonzero)
+    echo "provider boom ${HEIYUCODE_AUTH_TOKEN:-}" >&2
+    exit 17
+    ;;
+  empty)
+    write_response 200 ''
+    ;;
+  auth_fallback)
+    if [ "$count" -eq 1 ]; then
+      write_response 401 '{"code":"INVALID_API_KEY","message":"bad auth header"}'
+    else
+      write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.96,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}'
+    fi
+    ;;
+  *)
+    echo "unknown FAKE_CURL_MODE=${FAKE_CURL_MODE}" >&2
+    exit 2
+    ;;
+esac
+SH
+  chmod +x "$curl_path"
+}
+
+test_heiyucode_provider_uses_messages_api() {
   local tmp fake_bin calls
   tmp="$(mktemp -d)"
   fake_bin="$tmp/bin"
@@ -73,22 +144,13 @@ test_heiyucode_provider_uses_claude_code_client() {
   mkdir -p "$fake_bin" "$calls"
   make_repo "$tmp/repo"
 
-  cat > "$fake_bin/claude" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "${ANTHROPIC_BASE_URL:-}" > "$FAKE_CALL_DIR/claude.base_url"
-printf '%s\n' "${ANTHROPIC_AUTH_TOKEN:-}" > "$FAKE_CALL_DIR/claude.token"
-printf '%s\n' "$*" > "$FAKE_CALL_DIR/claude.args"
-cat <<'JSON'
-{"verdict":"PASS","checks":{"GPC-003":{"verdict":"PASS","confidence":0.96,"reason":"ok"}},"summary":"ok"}
-JSON
-SH
-  chmod +x "$fake_bin/claude"
+  write_fake_heiyucode_curl "$fake_bin/curl"
 
   (
     cd "$tmp/repo"
     PATH="$fake_bin:$PATH" \
       FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="pass" \
       SENTINEL_LLM_PROVIDER="heiyucode" \
       HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
       HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
@@ -96,10 +158,15 @@ SH
       "$ROOT_DIR/scripts/llm-review.sh"
   )
 
-  grep -q "https://www.heiyucode.com" "$calls/claude.base_url" || fail "HeiyuCode base URL not used"
-  grep -q "heiyucode-test-token" "$calls/claude.token" || fail "HeiyuCode token not used"
-  grep -q -- "--model claude-heiyu-test" "$calls/claude.args" || fail "HeiyuCode model not passed to Claude client"
-  jq -e '.provider == "heiyucode_claude_code" and .passed == true and .model == "claude-heiyu-test"' \
+  grep -q "Authorization: Bearer heiyucode-test-token" "$calls/curl.headers" || fail "HeiyuCode bearer token not used"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
+    and .http_status == "200"
+    and .auth_header_kind == "authorization_bearer"
+    and .passed == true
+    and .model == "claude-heiyu-test"
+  ' \
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "HeiyuCode result metadata mismatch"
 }
 
@@ -111,20 +178,14 @@ test_heiyucode_provider_hard_fails_explicit_fail_verdict() {
   mkdir -p "$fake_bin" "$calls"
   make_repo "$tmp/repo"
 
-  cat > "$fake_bin/claude" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-cat <<'JSON'
-{"verdict":"FAIL","checks":{"GPC-003":{"verdict":"FAIL","confidence":0.98,"reason":"policy conflict"}},"summary":"fail"}
-JSON
-SH
-  chmod +x "$fake_bin/claude"
+  write_fake_heiyucode_curl "$fake_bin/curl"
 
   set +e
   (
     cd "$tmp/repo"
     PATH="$fake_bin:$PATH" \
       FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="fail" \
       SENTINEL_LLM_PROVIDER="heiyucode" \
       HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
       HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
@@ -147,15 +208,7 @@ test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout() {
   mkdir -p "$fake_bin" "$calls"
   make_repo "$tmp/repo"
 
-  cat > "$fake_bin/claude" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-sleep 2
-cat <<'JSON'
-{"verdict":"PASS","checks":{"GPC-003":{"verdict":"PASS","confidence":0.96,"reason":"ok"}},"summary":"ok"}
-JSON
-SH
-  chmod +x "$fake_bin/claude"
+  write_fake_heiyucode_curl "$fake_bin/curl"
 
   started="$(date +%s)"
   set +e
@@ -163,6 +216,7 @@ SH
     cd "$tmp/repo"
     PATH="$fake_bin:$PATH" \
       FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="sleep" \
       SENTINEL_LLM_PROVIDER="heiyucode" \
       HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
       HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
@@ -178,6 +232,7 @@ SH
   [ "$elapsed" -lt 6 ] || fail "Timeout path waited too long: ${elapsed}s"
   jq -e '
     .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
     and .status == "error"
     and .error_type == "provider_error"
     and (.reason | test("timeout"))
@@ -197,19 +252,14 @@ test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics() {
   mkdir -p "$fake_bin" "$calls"
   make_repo "$tmp/repo"
 
-  cat > "$fake_bin/claude" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-echo "provider boom" >&2
-exit 17
-SH
-  chmod +x "$fake_bin/claude"
+  write_fake_heiyucode_curl "$fake_bin/curl"
 
   set +e
   (
     cd "$tmp/repo"
     PATH="$fake_bin:$PATH" \
       FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="nonzero" \
       SENTINEL_LLM_PROVIDER="heiyucode" \
       HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
       HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
@@ -222,6 +272,7 @@ SH
   [ "$status" -eq 0 ] || fail "Provider non-zero exit should be non-blocking ESCALATE"
   jq -e '
     .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
     and .model == "claude-heiyu-test"
     and .status == "error"
     and .error_type == "provider_error"
@@ -231,7 +282,9 @@ SH
     and .stdout_bytes == 0
     and .stderr_bytes > 0
     and (.stderr_tail | contains("provider boom"))
+    and (.stderr_tail | contains("[redacted]"))
     and .base_url_configured == true
+    and .api_url_configured == true
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Non-zero provider diagnostics mismatch"
 }
 
@@ -243,18 +296,14 @@ test_heiyucode_provider_empty_output_escalates_with_diagnostics() {
   mkdir -p "$fake_bin" "$calls"
   make_repo "$tmp/repo"
 
-  cat > "$fake_bin/claude" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-exit 0
-SH
-  chmod +x "$fake_bin/claude"
+  write_fake_heiyucode_curl "$fake_bin/curl"
 
   set +e
   (
     cd "$tmp/repo"
     PATH="$fake_bin:$PATH" \
       FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="empty" \
       SENTINEL_LLM_PROVIDER="heiyucode" \
       HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
       HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
@@ -267,6 +316,7 @@ SH
   [ "$status" -eq 0 ] || fail "Empty provider response should be non-blocking ESCALATE"
   jq -e '
     .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
     and .status == "error"
     and .error_type == "provider_error"
     and .reason == "No text in response"
@@ -279,11 +329,44 @@ SH
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty output diagnostics mismatch"
 }
 
+test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="auth_fallback" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  grep -q "Authorization: Bearer heiyucode-test-token" "$calls/curl.headers" || fail "Bearer auth was not attempted"
+  grep -q "x-api-key: heiyucode-test-token" "$calls/curl.headers" || fail "x-api-key fallback was not attempted"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
+    and .http_status == "200"
+    and .auth_header_kind == "x-api-key"
+    and .passed == true
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "x-api-key fallback result mismatch"
+}
+
 test_anthropic_provider_uses_messages_api
-test_heiyucode_provider_uses_claude_code_client
+test_heiyucode_provider_uses_messages_api
 test_heiyucode_provider_hard_fails_explicit_fail_verdict
 test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout
 test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics
 test_heiyucode_provider_empty_output_escalates_with_diagnostics
+test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure
 
 echo "llm-review provider router tests passed"


### PR DESCRIPTION
## Summary
- Route HeiyuCode LLM review through the Anthropic-compatible Messages API instead of the Claude Code CLI.
- Keep provider timeout/error as non-blocking ESCALATE with structured diagnostics.
- Add bearer-to-x-api-key auth fallback without logging secret values.

## Root Cause
The previous HeiyuCode path used the Claude Code CLI with ANTHROPIC_BASE_URL. In GitHub Actions it could sit for 420s with zero stdout/stderr, producing no content review and no useful provider signal.

## Validation
- bash tests/test-llm-review-provider-router.sh
- bash -n scripts/llm-review.sh
- git diff --check