### PR TITLE
docs(sentinel): align HeiyuCode transport wording

### DIFF
--- a/.github/workflows/consistency-sentinel.yml
+++ b/.github/workflows/consistency-sentinel.yml
@@ -19,7 +19,7 @@ on:
         default: 'auto'
         type: string
       heiyucode_base_url:
-        description: 'HeiyuCode Claude Code client base URL'
+        description: 'HeiyuCode Messages API base URL'
         required: false
         default: 'https://www.heiyucode.com'
         type: string


### PR DESCRIPTION
## Summary
- Replace stale reusable workflow input wording that still mentioned the Claude Code client with Messages API wording.

## Validation
- bash tests/test-llm-review-provider-router.sh
- git diff --check
- rg old Claude Code client terms: no matches