### PR TITLE
fix(caller-sync): 保持 boolean 默认值类型一致

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -5,7 +5,7 @@ on:
       dry_run:
         description: Preview only, do not create PRs
         required: false
-        default: 'true'
+        default: true
         type: boolean
   schedule:
     - cron: '0 0 * * 0'
@@ -33,7 +33,7 @@ env:
           skip_llm:
             description: 'Skip LLM review layer'
             required: false
-            default: 'false'
+            default: false
             type: boolean
     permissions:
       contents: read

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -13,6 +13,14 @@ if grep -q '\${{ inputs\.dry_run || '\''true'\'' }}' "$CALLER_SYNC_WORKFLOW"; th
   fail "caller-sync must not coerce boolean false dry_run input back to true"
 fi
 
+if grep -q "default: 'true'" "$CALLER_SYNC_WORKFLOW"; then
+  fail "caller-sync dry_run boolean input default must stay boolean true, not string 'true'"
+fi
+
+if grep -q "default: 'false'" "$CALLER_SYNC_WORKFLOW"; then
+  fail "caller-sync canonical skip_llm boolean input default must stay boolean false, not string 'false'"
+fi
+
 count="$(grep -c "github.event.inputs.dry_run || 'true'" "$CALLER_SYNC_WORKFLOW" || true)"
 if [ "$count" -ne 2 ]; then
   fail "caller-sync should default scheduled runs to dry_run=true while preserving workflow_dispatch dry_run=false"


### PR DESCRIPTION
## 目标

修复 caller-sync canonical workflow 中 boolean input 默认值被写成字符串的问题，避免下游 caller workflow 被仓库级门禁判定为类型语义不一致。

关联：huanlongAI/sentinel-shared#17；跟进 huanlongAI/hl-contracts#78 的 claude-gate 反馈。

## 变更

- 将 caller-sync 自身的 `dry_run` boolean 默认值从字符串 `'true'` 改为 boolean `true`
- 将 canonical caller workflow 的 `skip_llm` boolean 默认值从字符串 `'false'` 改为 boolean `false`
- 增加测试守卫，防止 boolean 默认值回退为字符串

## 验证

- `bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-dashboard-workflow.sh`
- `bash tests/test-d7-d8.sh`
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/caller-sync.yml .github/workflows/consistency-sentinel.yml`
