### PR TITLE
fix(sentinel): use file-backed llm review payloads

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -10,6 +10,18 @@ SENTINEL_SHARED_DIR="${SENTINEL_SHARED_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")
 
 mkdir -p "$RESULTS_DIR"
 
+cleanup_temp_files() {
+  rm -f \
+    "${SYSTEM_PROMPT_FILE:-}" \
+    "${USER_MSG_FILE:-}" \
+    "${REQUEST_BODY:-}" \
+    "${API_RESPONSE_FILE:-}" \
+    "${API_ERR_FILE:-}" \
+    "${API_META_FILE:-}"
+}
+
+trap cleanup_temp_files EXIT
+
 # --- YAML helpers (no yq) ---
 trim_yaml_value() {
   sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^[[:space:]]+|[[:space:]]+$//g' | tr -d '"' | tr -d "'"
@@ -400,11 +412,28 @@ Respond ONLY with a JSON object (no markdown wrapping):
   \"summary\": \"one-line summary\"
 }"
 
+SYSTEM_PROMPT_FILE="$(mktemp)"
+USER_MSG_FILE="$(mktemp)"
+REQUEST_BODY="$(mktemp)"
+
+printf '%s' "$SYSTEM_PROMPT_CONTENT" > "$SYSTEM_PROMPT_FILE"
+printf '%s' "$USER_MSG" > "$USER_MSG_FILE"
+
+build_messages_request_body() {
+  local request_body_file="$1"
+  jq -n \
+    --arg model "$LLM_MODEL" \
+    --argjson max_tokens "$LLM_MAX_TOKENS" \
+    --rawfile system "$SYSTEM_PROMPT_FILE" \
+    --rawfile user "$USER_MSG_FILE" \
+    '{model:$model,max_tokens:$max_tokens,system:$system,messages:[{role:"user",content:$user}]}' \
+    > "$request_body_file"
+}
+
+build_messages_request_body "$REQUEST_BODY"
+
 # --- Call provider ---
 echo "Calling LLM provider ($LLM_PROVIDER / $LLM_MODEL)..."
-
-SYSTEM_JSON=$(echo "$SYSTEM_PROMPT_CONTENT" | jq -Rsa .)
-USER_JSON=$(echo "$USER_MSG" | jq -Rsa .)
 
 RESPONSE_TEXT=""
 PROVIDER_TRANSPORT="${PROVIDER_TRANSPORT:-n/a}"
@@ -429,12 +458,7 @@ if [ "$LLM_PROVIDER" = "anthropic" ]; then
     -H "Content-Type: application/json" \
     -H "x-api-key: ${ANTHROPIC_API_KEY}" \
     -H "anthropic-version: 2023-06-01" \
-    -d "{
-      \"model\": \"${LLM_MODEL}\",
-      \"max_tokens\": ${LLM_MAX_TOKENS},
-      \"system\": ${SYSTEM_JSON},
-      \"messages\": [{\"role\": \"user\", \"content\": ${USER_JSON}}]
-    }" \
+    --data-binary "@${REQUEST_BODY}" \
     "https://api.anthropic.com/v1/messages" 2>&1) || true
 
   if [ -z "$API_RESPONSE" ]; then
@@ -469,17 +493,9 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
     HEIYUCODE_CLIENT_TIMEOUT_SECONDS=420
   fi
 
-  REQUEST_BODY="$(mktemp)"
-  API_RESPONSE="$(mktemp)"
-  API_ERR="$(mktemp)"
-  API_META="$(mktemp)"
-  jq -n \
-    --arg model "$LLM_MODEL" \
-    --argjson max_tokens "$LLM_MAX_TOKENS" \
-    --arg system "$SYSTEM_PROMPT_CONTENT" \
-    --arg user "$USER_MSG" \
-    '{model:$model,max_tokens:$max_tokens,system:$system,messages:[{role:"user",content:$user}]}' \
-    > "$REQUEST_BODY"
+  API_RESPONSE_FILE="$(mktemp)"
+  API_ERR_FILE="$(mktemp)"
+  API_META_FILE="$(mktemp)"
 
   call_heiyucode_messages() {
     local auth_header_kind="$1"
@@ -542,16 +558,16 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
     local auth_header_kind="$1"
     PROVIDER_ATTEMPTS="$(( ${PROVIDER_ATTEMPTS:-0} + 1 ))"
     set +e
-    call_heiyucode_messages "$auth_header_kind" "$API_RESPONSE" "$API_ERR" "$API_META"
+    call_heiyucode_messages "$auth_header_kind" "$API_RESPONSE_FILE" "$API_ERR_FILE" "$API_META_FILE"
     client_status="$?"
     set -e
     client_duration="$(( $(date +%s) - client_started ))"
-    HTTP_STATUS="$(extract_http_status "$API_META")"
+    HTTP_STATUS="$(extract_http_status "$API_META_FILE")"
     PROVIDER_HTTP_STATUS="$HTTP_STATUS"
     PROVIDER_EXIT_CODE="$client_status"
     PROVIDER_DURATION_SECONDS="$client_duration"
-    PROVIDER_STDOUT_BYTES="$(file_size_bytes "$API_RESPONSE")"
-    PROVIDER_STDERR_BYTES="$(file_size_bytes "$API_ERR")"
+    PROVIDER_STDOUT_BYTES="$(file_size_bytes "$API_RESPONSE_FILE")"
+    PROVIDER_STDERR_BYTES="$(file_size_bytes "$API_ERR_FILE")"
   }
 
   run_heiyucode_attempt "$AUTH_HEADER_KIND"
@@ -570,34 +586,34 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   done
 
   if [ "$client_status" -eq 124 ]; then
-    write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE" "$API_ERR"
+    write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     exit 0
   fi
   if [ "$client_status" -ne 0 ]; then
-    write_provider_error_result "HeiyuCode Messages API curl error" "$client_status" "$client_duration" "$API_RESPONSE" "$API_ERR"
+    write_provider_error_result "HeiyuCode Messages API curl error" "$client_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     exit 0
   fi
 
   if ! [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
     if [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; then
-      write_provider_error_result "HeiyuCode Messages API auth error HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE" "$API_ERR"
+      write_provider_error_result "HeiyuCode Messages API auth error HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     else
-      write_provider_error_result "HeiyuCode Messages API HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE" "$API_ERR"
+      write_provider_error_result "HeiyuCode Messages API HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     fi
     exit 0
   fi
 
   set +e
-  RESPONSE_TEXT="$(jq -r '[.content[]? | select(.type == "text") | .text] | join("\n\n")' "$API_RESPONSE" 2>"$API_ERR")"
+  RESPONSE_TEXT="$(jq -r '[.content[]? | select(.type == "text") | .text] | join("\n\n")' "$API_RESPONSE_FILE" 2>"$API_ERR_FILE")"
   parse_status="$?"
   set -e
   if [ "$parse_status" -ne 0 ]; then
-    write_provider_error_result "HeiyuCode Messages API returned invalid JSON" "$parse_status" "$client_duration" "$API_RESPONSE" "$API_ERR"
+    write_provider_error_result "HeiyuCode Messages API returned invalid JSON" "$parse_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     exit 0
   fi
 
   if [ -z "$RESPONSE_TEXT" ]; then
-    write_provider_error_result "No text in response" 0 "$client_duration" "$API_RESPONSE" "$API_ERR"
+    write_provider_error_result "No text in response" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     exit 0
   fi
 fi

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -33,6 +33,28 @@ EOF
   git -C "$dir" commit -q -m "change"
 }
 
+append_large_anchor_files() {
+  local dir="$1"
+  local count="${2:-48}"
+  local size_bytes="${3:-45000}"
+  local i anchor_path
+
+  mkdir -p "$dir/anchors"
+  cat >> "$dir/.sentinel/config.yaml" <<'YAML'
+anchor_files:
+YAML
+
+  for i in $(seq 1 "$count"); do
+    anchor_path="$dir/anchors/context-${i}.md"
+    {
+      printf 'anchor-%s\n' "$i"
+      head -c "$size_bytes" /dev/zero | tr '\0' 'x'
+      printf '\n'
+    } > "$anchor_path"
+    printf '  context_%s: "anchors/context-%s.md"\n' "$i" "$i" >> "$dir/.sentinel/config.yaml"
+  done
+}
+
 test_anthropic_provider_uses_messages_api() {
   local tmp fake_bin calls
   tmp="$(mktemp -d)"
@@ -70,6 +92,8 @@ write_fake_heiyucode_curl() {
   cat > "$curl_path" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
 
 out=""
 while [ "$#" -gt 0 ]; do
@@ -146,6 +170,19 @@ SH
   chmod +x "$curl_path"
 }
 
+write_recording_jq() {
+  local jq_path="$1"
+  local real_jq
+  real_jq="$(command -v jq)"
+  cat > "$jq_path" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >> "\$FAKE_CALL_DIR/jq.args"
+exec "$real_jq" "\$@"
+SH
+  chmod +x "$jq_path"
+}
+
 test_heiyucode_provider_uses_messages_api() {
   local tmp fake_bin calls
   tmp="$(mktemp -d)"
@@ -155,6 +192,7 @@ test_heiyucode_provider_uses_messages_api() {
   make_repo "$tmp/repo"
 
   write_fake_heiyucode_curl "$fake_bin/curl"
+  write_recording_jq "$fake_bin/jq"
 
   (
     cd "$tmp/repo"
@@ -169,6 +207,15 @@ test_heiyucode_provider_uses_messages_api() {
   )
 
   grep -q "Authorization: Bearer heiyucode-test-token" "$calls/curl.headers" || fail "HeiyuCode bearer token not used"
+  grep -q -- '--data-binary @' "$calls/curl.args" || fail "HeiyuCode request body should be sent via file-backed --data-binary"
+  grep -q -- '--rawfile system' "$calls/jq.args" || fail "HeiyuCode request body should load system prompt from file"
+  grep -q -- '--rawfile user' "$calls/jq.args" || fail "HeiyuCode request body should load user prompt from file"
+  if grep -q -- '--arg system ' "$calls/jq.args"; then
+    fail "HeiyuCode request body should not pass system prompt via --arg"
+  fi
+  if grep -q -- '--arg user ' "$calls/jq.args"; then
+    fail "HeiyuCode request body should not pass user prompt via --arg"
+  fi
   jq -e '
     .provider == "heiyucode_claude_code"
     and .transport == "messages-api"
@@ -456,7 +503,84 @@ test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "x-api-key fallback result mismatch"
 }
 
+test_request_body_uses_file_backed_payload_for_anthropic() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+cat <<'JSON'
+{"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.95,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+  write_recording_jq "$fake_bin/jq"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  grep -q -- '--data-binary @' "$calls/curl.args" || fail "Anthropic request body should be sent via file-backed --data-binary"
+  grep -q -- '--rawfile system' "$calls/jq.args" || fail "Anthropic request body should load system prompt from file"
+  grep -q -- '--rawfile user' "$calls/jq.args" || fail "Anthropic request body should load user prompt from file"
+  if grep -q -- '--arg system ' "$calls/jq.args"; then
+    fail "Anthropic request body should not pass system prompt via --arg"
+  fi
+  if grep -q -- '--arg user ' "$calls/jq.args"; then
+    fail "Anthropic request body should not pass user prompt via --arg"
+  fi
+}
+
+test_large_prompt_uses_file_backed_payload_without_arg_list_overflow() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  append_large_anchor_files "$tmp/repo"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+cat <<'JSON'
+{"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.95,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+  write_recording_jq "$fake_bin/jq"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  grep -q -- '--data-binary @' "$calls/curl.args" || fail "Large prompt request body should be sent via file-backed --data-binary"
+  grep -q -- '--rawfile system' "$calls/jq.args" || fail "Large prompt request body should load system prompt from file"
+  grep -q -- '--rawfile user' "$calls/jq.args" || fail "Large prompt request body should load user prompt from file"
+  jq -e '.provider == "anthropic" and .passed == true' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Large prompt result metadata mismatch"
+}
+
 test_anthropic_provider_uses_messages_api
+test_request_body_uses_file_backed_payload_for_anthropic
+test_large_prompt_uses_file_backed_payload_without_arg_list_overflow
 test_heiyucode_provider_uses_messages_api
 test_heiyucode_provider_hard_fails_explicit_fail_verdict
 test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout


### PR DESCRIPTION
## Summary

- Build LLM request bodies from temp files with jq --rawfile instead of passing large prompts as command arguments.
- Send Anthropic-compatible provider requests with curl --data-binary @request_body_file.
- Add regression coverage for large prompt payloads to guard against argument-list overflow.

## Tests

- bash tests/test-llm-review-provider-router.sh

## Dispatch Evidence

- Fix scope: tooling_only_file_backed_payload
- Head SHA: 340ecb494cb7d8a4b89e7c5130fd915a7eb9f425
- Related: huanlongAI/hl-dispatch#172