### PR TITLE
ci: 添加 sentinel-shared 自检门禁

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,47 @@
+name: Sentinel Shared Self Test
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".sentinel/checks/**"
+      - "scripts/**"
+      - "tests/**"
+      - "prompts/**"
+      - "matrix/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".sentinel/checks/**"
+      - "scripts/**"
+      - "tests/**"
+      - "prompts/**"
+      - "matrix/**"
+
+permissions:
+  contents: read
+
+jobs:
+  sentinel-shared-gate:
+    name: Sentinel Shared Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run shell regression tests
+        run: |
+          bash tests/test-policy-file.sh
+          bash tests/test-d7-d8.sh
+          bash tests/test-caller-sync-workflow.sh
+          bash tests/test-dashboard-workflow.sh
+          bash tests/test-llm-review-provider-router.sh
+          bash tests/test-self-test-workflow.sh
+
+      - name: Check shell syntax
+        run: bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh
+
+      - name: Check workflow YAML syntax
+        run: |
+          ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'

--- a/tests/test-self-test-workflow.sh
+++ b/tests/test-self-test-workflow.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/self-test.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq -- "$needle" "$file"; then
+    fail "$file must contain: $needle"
+  fi
+}
+
+if [ ! -f "$WORKFLOW" ]; then
+  fail "Sentinel shared self-test workflow is missing"
+fi
+
+assert_file_contains "$WORKFLOW" "name: Sentinel Shared Self Test"
+assert_file_contains "$WORKFLOW" "pull_request:"
+assert_file_contains "$WORKFLOW" "push:"
+assert_file_contains "$WORKFLOW" "branches: [main]"
+assert_file_contains "$WORKFLOW" "name: Sentinel Shared Gate"
+assert_file_contains "$WORKFLOW" "actions/checkout@v5"
+assert_file_contains "$WORKFLOW" "bash tests/test-policy-file.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-d7-d8.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-caller-sync-workflow.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-dashboard-workflow.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-llm-review-provider-router.sh"
+assert_file_contains "$WORKFLOW" "bash tests/test-self-test-workflow.sh"
+assert_file_contains "$WORKFLOW" "bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh"
+
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$WORKFLOW"
+
+echo "self-test workflow shape test passed"


### PR DESCRIPTION
## 变更\n\n- 新增 Sentinel Shared Self Test workflow，提供稳定 required-check context：Sentinel Shared Gate。\n- 新增 tests/test-self-test-workflow.sh，回归检查自检 workflow 的触发范围、job 名和本地验证命令。\n\n## 目的\n\n收口 sentinel-shared#90：先建立稳定自检门禁，再配置 main required checks。\n\n## 本地验证\n\n- bash tests/test-self-test-workflow.sh\n- bash tests/test-policy-file.sh\n- bash tests/test-d7-d8.sh\n- bash tests/test-caller-sync-workflow.sh\n- bash tests/test-dashboard-workflow.sh\n- bash tests/test-llm-review-provider-router.sh\n- bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh\n- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'\n- git diff --check HEAD~1..HEAD\n\nIssue: https://github.com/huanlongAI/sentinel-shared/issues/90