### PR TITLE
fix(caller-sync): 保持 boolean 默认值类型一致

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -5,7 +5,7 @@ on:
       dry_run:
         description: Preview only, do not create PRs
         required: false
-        default: 'true'
+        default: true
         type: boolean
   schedule:
     - cron: '0 0 * * 0'
@@ -33,7 +33,7 @@ env:
           skip_llm:
             description: 'Skip LLM review layer'
             required: false
-            default: 'false'
+            default: false
             type: boolean
     permissions:
       contents: read

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -13,6 +13,14 @@ if grep -q '\${{ inputs\.dry_run || '\''true'\'' }}' "$CALLER_SYNC_WORKFLOW"; th
   fail "caller-sync must not coerce boolean false dry_run input back to true"
 fi
 
+if grep -q "default: 'true'" "$CALLER_SYNC_WORKFLOW"; then
+  fail "caller-sync dry_run boolean input default must stay boolean true, not string 'true'"
+fi
+
+if grep -q "default: 'false'" "$CALLER_SYNC_WORKFLOW"; then
+  fail "caller-sync canonical skip_llm boolean input default must stay boolean false, not string 'false'"
+fi
+
 count="$(grep -c "github.event.inputs.dry_run || 'true'" "$CALLER_SYNC_WORKFLOW" || true)"
 if [ "$count" -ne 2 ]; then
   fail "caller-sync should default scheduled runs to dry_run=true while preserving workflow_dispatch dry_run=false"


### PR DESCRIPTION
## 变更\n\n- 将 caller-sync workflow_dispatch dry_run 默认值从字符串 'true' 改为 boolean true。\n- 将 canonical caller workflow skip_llm 默认值从字符串 'false' 改为 boolean false。\n- 补充 tests/test-caller-sync-workflow.sh 回归测试，防止 boolean input default 再退回字符串。\n\n## 背景\n\n这是 #81 的当前 main 窄分支重放版本；#81 已落后 main，且缺少 #91 后新增的 Sentinel Shared Gate fresh check。\n\n## 本地验证\n\n- bash tests/test-caller-sync-workflow.sh\n- bash tests/test-self-test-workflow.sh\n- bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh\n- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'\n- git diff --check HEAD~1..HEAD\n\nSupersedes: https://github.com/huanlongAI/sentinel-shared/pull/81