### PR TITLE
fix(d7-d8): 清理空数组结果输出噪声

### DIFF
--- a/.sentinel/checks/d7-reverse-ssot.sh
+++ b/.sentinel/checks/d7-reverse-ssot.sh
@@ -64,12 +64,18 @@ if [ "${#issues[@]}" -gt 0 ]; then
   passed=false
 fi
 
+if [ "${#issues[@]}" -gt 0 ]; then
+  issues_json="$(json_string_array "${issues[@]}")"
+else
+  issues_json="$(json_string_array)"
+fi
+
 cat > "$result_file" <<EOF
 {
   "check_id": "D-7",
   "check_name": "Reverse SSOT",
   "passed": $passed,
-  "issues": $(json_string_array "${issues[@]}"),
+  "issues": $issues_json,
   "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF

--- a/.sentinel/checks/d8-cross-repo-ssot.sh
+++ b/.sentinel/checks/d8-cross-repo-ssot.sh
@@ -75,13 +75,19 @@ write_result() {
   local status="$1"
   shift
   local warnings=("$@")
+  local warnings_json
+  if [ "${#warnings[@]}" -gt 0 ]; then
+    warnings_json="$(json_string_array "${warnings[@]}")"
+  else
+    warnings_json="$(json_string_array)"
+  fi
   cat > "$result_file" <<EOF
 {
   "check_id": "D-8",
   "check_name": "Cross-Repo SSOT",
   "passed": $passed,
   "status": "$status",
-  "warnings": $(json_string_array "${warnings[@]}"),
+  "warnings": $warnings_json,
   "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF

--- a/tests/test-d7-d8.sh
+++ b/tests/test-d7-d8.sh
@@ -18,6 +18,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "Expected output not to contain: $needle"
+    echo "Actual output:"
+    echo "$haystack"
+    exit 1
+  fi
+}
+
 pass() {
   PASS_COUNT=$((PASS_COUNT + 1))
   echo "ok - $1"
@@ -115,8 +126,9 @@ trap 'rm -rf "$TMP_ROOT"' EXIT
 # D-7 pass.
 D7_PASS_DIR="$TMP_ROOT/d7-pass"
 make_guanghe_docs "$D7_PASS_DIR" "0.6.0-alpha" "0.6.0-alpha"
-(cd "$D7_PASS_DIR" && RESULTS_DIR="$TMP_ROOT/results-d7-pass" "$D7_SCRIPT") >/tmp/d7-pass.out
-assert_contains "$(cat /tmp/d7-pass.out)" "PASS: D-7 reverse SSOT consistent at 0.6.0-alpha"
+D7_PASS_OUTPUT=$(cd "$D7_PASS_DIR" && RESULTS_DIR="$TMP_ROOT/results-d7-pass" "$D7_SCRIPT" 2>&1)
+assert_contains "$D7_PASS_OUTPUT" "PASS: D-7 reverse SSOT consistent at 0.6.0-alpha"
+assert_not_contains "$D7_PASS_OUTPUT" "unbound variable"
 pass "D-7 accepts matching README and CLAUDE-CONTEXT versions"
 
 # D-7 drift blocks.
@@ -139,8 +151,9 @@ UPSTREAM_DIR="$TMP_ROOT/upstream"
 D8_CURRENT_DIR="$TMP_ROOT/d8-current"
 make_upstream "$UPSTREAM_DIR"
 make_downstream_semver "$D8_CURRENT_DIR" "0.6.0-alpha"
-D8_CURRENT_OUTPUT=$(UPSTREAM_DIR="$UPSTREAM_DIR" DOWNSTREAM_DIR="$D8_CURRENT_DIR" RESULTS_DIR="$TMP_ROOT/results-d8-current" "$D8_SCRIPT")
+D8_CURRENT_OUTPUT=$(UPSTREAM_DIR="$UPSTREAM_DIR" DOWNSTREAM_DIR="$D8_CURRENT_DIR" RESULTS_DIR="$TMP_ROOT/results-d8-current" "$D8_SCRIPT" 2>&1)
 assert_contains "$D8_CURRENT_OUTPUT" "PASS: D-8 downstream pin 0.6.0-alpha is within allowed drift"
+assert_not_contains "$D8_CURRENT_OUTPUT" "unbound variable"
 pass "D-8 accepts current semver pin"
 
 # D-8 old semver emits WARN but does not block.


### PR DESCRIPTION
## Scope

从冲突大 PR #60 中拆出 D-7/D-8 的低风险窄修复：当 result JSON 的 issues/warnings 为空时，不再在 bash set -u 下展开空数组导致 unbound variable 噪声。

## Changes

- D-7 result JSON 写入前显式生成 issues_json。
- D-8 result JSON 写入前显式生成 warnings_json。
- 回归测试捕获 stdout/stderr，并断言成功路径不包含 unbound variable。

## Verification

- bash tests/test-d7-d8.sh
- bash tests/test-self-test-workflow.sh
- bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'
- git diff --check HEAD~1..HEAD

## Related

- Split from stale/conflicting #60.
- Keeps #60 open for remaining LLM fail-closed and cascade fail-closed decisions.