### PR TITLE
fix(llm-review): 启用时失败路径 fail closed

### DIFF
--- a/.github/workflows/consistency-sentinel.yml
+++ b/.github/workflows/consistency-sentinel.yml
@@ -114,7 +114,12 @@ jobs:
       - name: "聚合判定 & 生成报告"
         id: aggregate
         if: always()
-        run: .sentinel-shared/scripts/aggregate.sh
+        run: |
+          REQUIRED_RESULTS="d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json"
+          if [ "${{ inputs.skip_llm }}" != "true" ]; then
+            REQUIRED_RESULTS="$REQUIRED_RESULTS llm-review.json"
+          fi
+          REQUIRED_RESULT_FILES="$REQUIRED_RESULTS" .sentinel-shared/scripts/aggregate.sh
 
       # ---- PR Comment ----
       - name: "发布报告到 PR"

--- a/scripts/aggregate.sh
+++ b/scripts/aggregate.sh
@@ -13,8 +13,29 @@ mkdir -p "$RESULTS_DIR"
 echo "Verdict Aggregation"
 echo "Results directory: $RESULTS_DIR"
 
-# Find all d*-*.json files in results directory
-RESULT_FILES=$(find "$RESULTS_DIR" -maxdepth 1 -name "d*-*.json" -type f | sort)
+REQUIRED_RESULT_FILES="${REQUIRED_RESULT_FILES:-d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json}"
+if [ -n "$REQUIRED_RESULT_FILES" ]; then
+  for required_result in $REQUIRED_RESULT_FILES; do
+    [ -z "$required_result" ] && continue
+    if [ ! -f "$RESULTS_DIR/$required_result" ]; then
+      echo "::error::Required sentinel result missing: $required_result"
+      jq -n \
+        --arg file "$required_result" \
+        --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{
+          check_id: "D-MISSING",
+          check_name: "Missing Result",
+          passed: false,
+          status: "missing",
+          issues: ["Required sentinel result file missing: " + $file],
+          timestamp: $timestamp
+        }' > "$RESULTS_DIR/$required_result"
+    fi
+  done
+fi
+
+# Find deterministic check files plus optional LLM review result.
+RESULT_FILES=$(find "$RESULTS_DIR" -maxdepth 1 \( -name "d*-*.json" -o -name "llm-review.json" \) -type f | sort)
 
 if [ -z "$RESULT_FILES" ]; then
   echo "No result files found in $RESULTS_DIR"
@@ -45,8 +66,8 @@ while IFS= read -r result_file; do
   fi
 
   # Parse JSON result
-  check_id=$(jq -r '.check_id // "unknown"' "$result_file" 2>/dev/null || echo "unknown")
-  check_name=$(jq -r '.check_name // "unknown"' "$result_file" 2>/dev/null || echo "unknown")
+  check_id=$(jq -r '.check_id // .review_id // "unknown"' "$result_file" 2>/dev/null || echo "unknown")
+  check_name=$(jq -r '.check_name // (if (.review_id // "") == "llm-review" then "LLM Review" else "unknown" end)' "$result_file" 2>/dev/null || echo "unknown")
   passed=$(jq -r '.passed // false' "$result_file" 2>/dev/null || echo "false")
 
   echo "  Check: $check_id - $check_name"
@@ -60,7 +81,7 @@ while IFS= read -r result_file; do
     FAILED_CHECKS=$((FAILED_CHECKS + 1))
 
     # Extract issues
-    issues=$(jq -r '.issues[]? // .violations[]? // empty' "$result_file" 2>/dev/null || true)
+    issues=$(jq -r '([.issues[]?, .violations[]?] + (if (.reason // "") != "" then [.reason] else [] end))[]?' "$result_file" 2>/dev/null || true)
     while IFS= read -r issue; do
       [ -z "$issue" ] && continue
       ALL_ISSUES+=("[$check_id] $issue")
@@ -147,10 +168,10 @@ REPORT_FILE="$RESULTS_DIR/sentinel-report.md"
   while IFS= read -r result_file; do
     [ -z "$result_file" ] && continue
     [ ! -f "$result_file" ] && continue
-    r_id=$(jq -r '.check_id // "?"' "$result_file" 2>/dev/null || echo "?")
-    r_name=$(jq -r '.check_name // "?"' "$result_file" 2>/dev/null || echo "?")
+    r_id=$(jq -r '.check_id // .review_id // "?"' "$result_file" 2>/dev/null || echo "?")
+    r_name=$(jq -r '.check_name // (if (.review_id // "") == "llm-review" then "LLM Review" else "?" end)' "$result_file" 2>/dev/null || echo "?")
     r_pass=$(jq -r '.passed // false' "$result_file" 2>/dev/null || echo "false")
-    r_issues=$(jq -r '([.issues[]?, .violations[]?] | join("; ")) // ""' "$result_file" 2>/dev/null || echo "")
+    r_issues=$(jq -r '([.issues[]?, .violations[]?] + (if (.reason // "") != "" then [.reason] else [] end) | join("; ")) // ""' "$result_file" 2>/dev/null || echo "")
     if [ "$r_pass" = "true" ]; then
       echo "| ${r_id} ${r_name} | ✅ | — |"
     else

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -98,6 +98,26 @@ write_skip_result() {
 EOF
 }
 
+write_error_result() {
+  local reason="$1"
+  jq -n \
+    --arg provider "$LLM_PROVIDER" \
+    --arg model "$LLM_MODEL" \
+    --arg reason "$reason" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      review_id: "llm-review",
+      check_name: "LLM Review",
+      provider: $provider,
+      model: $model,
+      status: "error",
+      reason: $reason,
+      passed: false,
+      escalate: true,
+      timestamp: $timestamp
+    }' > "$RESULTS_DIR/llm-review.json"
+}
+
 file_size_bytes() {
   local file="$1"
   if [ -f "$file" ]; then
@@ -185,7 +205,7 @@ write_provider_error_result() {
       status: $status,
       error_type: $error_type,
       reason: $reason,
-      passed: true,
+      passed: false,
       escalate: true,
       http_status: $http_status,
       auth_header_kind: $auth_header_kind,
@@ -201,7 +221,7 @@ write_provider_error_result() {
       timestamp: $timestamp
     }' > "$RESULTS_DIR/llm-review.json"
 
-  echo "::warning::${reason} — ESCALATE (provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${provider_transport} http_status=${provider_http_status} auth_header_kind=${provider_auth_header_kind} exit_code=${exit_code} attempts=${provider_attempts} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured} api_url_configured=${api_url_configured})"
+  echo "::error::${reason} — fail closed (provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${provider_transport} http_status=${provider_http_status} auth_header_kind=${provider_auth_header_kind} exit_code=${exit_code} attempts=${provider_attempts} duration_seconds=${duration_seconds} stdout_bytes=${stdout_bytes} stderr_bytes=${stderr_bytes} base_url_configured=${base_url_configured} api_url_configured=${api_url_configured})"
 }
 
 run_with_timeout() {
@@ -288,15 +308,15 @@ fi
 echo "Config: provider=$LLM_PROVIDER model=$LLM_MODEL max_tokens=$LLM_MAX_TOKENS threshold=$CONFIDENCE_THRESHOLD"
 
 if [ "$LLM_PROVIDER" = "unsupported" ]; then
-  echo "::warning::Unsupported LLM provider '$REQUESTED_PROVIDER' — skipping LLM review"
-  write_skip_result "Unsupported LLM provider: ${REQUESTED_PROVIDER}"
-  exit 0
+  echo "::error::Unsupported LLM provider '$REQUESTED_PROVIDER' — fail closed"
+  write_error_result "Unsupported LLM provider: ${REQUESTED_PROVIDER}"
+  exit 1
 fi
 
 if [ "$LLM_PROVIDER" = "none" ]; then
-  echo "::warning::No LLM provider credentials configured — skipping LLM review"
-  write_skip_result "No LLM provider credentials configured"
-  exit 0
+  echo "::error::No LLM provider credentials configured — fail closed"
+  write_error_result "No LLM provider credentials configured"
+  exit 1
 fi
 
 if [ -z "$LLM_CHECKS" ]; then
@@ -449,9 +469,9 @@ PROVIDER_API_URL_CONFIGURED="${PROVIDER_API_URL_CONFIGURED:-false}"
 
 if [ "$LLM_PROVIDER" = "anthropic" ]; then
   if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "::warning::ANTHROPIC_API_KEY not set — skipping LLM review"
-    write_skip_result "ANTHROPIC_API_KEY not configured"
-    exit 0
+    echo "::error::ANTHROPIC_API_KEY not set — fail closed"
+    write_error_result "ANTHROPIC_API_KEY not configured"
+    exit 1
   fi
 
   API_RESPONSE=$(curl -s --max-time 120 \
@@ -462,20 +482,16 @@ if [ "$LLM_PROVIDER" = "anthropic" ]; then
     "https://api.anthropic.com/v1/messages" 2>&1) || true
 
   if [ -z "$API_RESPONSE" ]; then
-    echo "::warning::Claude API returned empty response — ESCALATE"
-    cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"Empty API response","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-    exit 0
+    echo "::error::Claude API returned empty response — fail closed"
+    write_error_result "Empty API response"
+    exit 1
   fi
 
   API_ERROR=$(echo "$API_RESPONSE" | jq -r '.error.message // empty' 2>/dev/null || true)
   if [ -n "$API_ERROR" ]; then
-    echo "::warning::Claude API error: $API_ERROR — ESCALATE"
-    cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"API error: ${API_ERROR}","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-    exit 0
+    echo "::error::Claude API error: $API_ERROR — fail closed"
+    write_error_result "API error: ${API_ERROR}"
+    exit 1
   fi
 
   RESPONSE_TEXT=$(echo "$API_RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
@@ -486,7 +502,7 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
 
   if [ -z "$HEIYUCODE_TOKEN" ]; then
     write_provider_error_result "HeiyuCode token not configured" 0 0 /dev/null /dev/null
-    exit 0
+    exit 1
   fi
 
   if ! [[ "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]] || [ "$HEIYUCODE_CLIENT_TIMEOUT_SECONDS" -lt 1 ]; then
@@ -587,11 +603,11 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
 
   if [ "$client_status" -eq 124 ]; then
     write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 0
+    exit 1
   fi
   if [ "$client_status" -ne 0 ]; then
     write_provider_error_result "HeiyuCode Messages API curl error" "$client_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 0
+    exit 1
   fi
 
   if ! [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
@@ -600,7 +616,7 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
     else
       write_provider_error_result "HeiyuCode Messages API HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
     fi
-    exit 0
+    exit 1
   fi
 
   set +e
@@ -609,21 +625,19 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   set -e
   if [ "$parse_status" -ne 0 ]; then
     write_provider_error_result "HeiyuCode Messages API returned invalid JSON" "$parse_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 0
+    exit 1
   fi
 
   if [ -z "$RESPONSE_TEXT" ]; then
     write_provider_error_result "No text in response" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 0
+    exit 1
   fi
 fi
 
 if [ -z "$RESPONSE_TEXT" ]; then
-  echo "::warning::No text in provider response — ESCALATE"
-  cat > "$RESULTS_DIR/llm-review.json" <<EOF
-{"review_id":"llm-review","provider":"$LLM_PROVIDER","model":"$LLM_MODEL","status":"error","reason":"No text in response","passed":true,"escalate":true,"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-EOF
-  exit 0
+  echo "::error::No text in provider response — fail closed"
+  write_error_result "No text in response"
+  exit 1
 fi
 
 echo "Response received (${#RESPONSE_TEXT} chars)"
@@ -648,12 +662,13 @@ if echo "$REVIEW_JSON" | jq . >/dev/null 2>&1; then
   echo "Summary: $SUMMARY"
   echo "$REVIEW_JSON" | jq -r '.checks // {} | to_entries[] | "  \(.key): \(.value.verdict) (confidence: \(.value.confidence // "N/A"))"' 2>/dev/null || true
 
-  if [ "$VERDICT" = "FAIL" ]; then
+  if [ "$VERDICT" = "FAIL" ] || [ "$VERDICT" = "ESCALATE" ]; then
     PASSED=false
   fi
 else
-  echo "::warning::Could not parse LLM JSON — ESCALATE"
-  REVIEW_JSON="{}"
+  echo "::error::Could not parse LLM JSON — fail closed"
+  write_error_result "Could not parse LLM JSON"
+  exit 1
 fi
 
 # --- Write result ---
@@ -688,7 +703,7 @@ EOF
 echo "Result written to $RESULT_FILE"
 
 if [ "$PASSED" = false ]; then
-  echo "::warning::LLM review verdict: FAIL"
+  echo "::warning::LLM review verdict: $VERDICT"
   exit 1
 fi
 

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -8,6 +8,14 @@ fail() {
   exit 1
 }
 
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail "Expected output to contain: $needle"
+  fi
+}
+
 make_repo() {
   local dir="$1"
   mkdir -p "$dir/.sentinel/results" "$dir/.sentinel/prompts"
@@ -133,6 +141,9 @@ case "${FAKE_CURL_MODE}" in
     ;;
   fail)
     write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"FAIL\",\"checks\":{\"GPC-003\":{\"verdict\":\"FAIL\",\"confidence\":0.98,\"reason\":\"policy conflict\"}},\"summary\":\"fail\"}"}]}'
+    ;;
+  escalate)
+    write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"ESCALATE\",\"checks\":{\"GPC-003\":{\"verdict\":\"ESCALATE\",\"confidence\":0.80,\"reason\":\"needs owner review\"}},\"summary\":\"escalate\"}"}]}'
     ;;
   sleep)
     sleep 2
@@ -264,7 +275,109 @@ test_heiyucode_provider_hard_fails_explicit_fail_verdict() {
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Explicit FAIL result mismatch"
 }
 
-test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout() {
+test_anthropic_api_error_fails_closed() {
+  local tmp fake_bin calls output code
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+cat <<'JSON'
+{"error":{"message":"provider unavailable"}}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  set +e
+  output=$(
+    cd "$tmp/repo" && \
+      PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh" 2>&1
+  )
+  code=$?
+  set -e
+
+  [ "$code" -ne 0 ] || fail "Anthropic API errors must fail closed"
+  assert_contains "$output" "fail closed"
+  jq -e '.provider == "anthropic" and .status == "error" and .passed == false and .escalate == true' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Anthropic API error result must fail"
+}
+
+test_anthropic_empty_text_fails_closed() {
+  local tmp fake_bin calls output code
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+cat <<'JSON'
+{"content":[{"text":""}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  set +e
+  output=$(
+    cd "$tmp/repo" && \
+      PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh" 2>&1
+  )
+  code=$?
+  set -e
+
+  [ "$code" -ne 0 ] || fail "Empty provider text must fail closed"
+  assert_contains "$output" "fail closed"
+  jq -e '.provider == "anthropic" and .status == "error" and .passed == false and .escalate == true' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty response result must fail"
+}
+
+test_heiyucode_provider_hard_fails_explicit_escalate_verdict() {
+  local tmp fake_bin calls status
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="escalate" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+
+  [ "$status" -ne 0 ] || fail "Explicit ESCALATE verdict should hard fail"
+  jq -e '.provider == "heiyucode_claude_code" and .verdict == "ESCALATE" and .passed == false' \
+    "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Explicit ESCALATE result mismatch"
+}
+
+test_heiyucode_provider_timeout_fails_closed_without_waiting_for_job_timeout() {
   local tmp fake_bin calls status started elapsed
   tmp="$(mktemp -d)"
   fake_bin="$tmp/bin"
@@ -292,7 +405,7 @@ test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout() {
   set -e
   elapsed="$(( $(date +%s) - started ))"
 
-  [ "$status" -eq 0 ] || fail "Timeout should be non-blocking ESCALATE"
+  [ "$status" -ne 0 ] || fail "Timeout should fail closed"
   [ "$elapsed" -lt 6 ] || fail "Timeout path waited too long: ${elapsed}s"
   jq -e '
     .provider == "heiyucode_claude_code"
@@ -300,7 +413,7 @@ test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout() {
     and .status == "error"
     and .error_type == "provider_error"
     and (.reason | test("timeout"))
-    and .passed == true
+    and .passed == false
     and .escalate == true
     and .exit_code == 124
     and .duration_seconds >= 1
@@ -308,7 +421,7 @@ test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Timeout provider diagnostics mismatch"
 }
 
-test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics() {
+test_heiyucode_provider_nonzero_exit_fails_closed_with_diagnostics() {
   local tmp fake_bin calls status
   tmp="$(mktemp -d)"
   fake_bin="$tmp/bin"
@@ -333,14 +446,14 @@ test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics() {
   status="$?"
   set -e
 
-  [ "$status" -eq 0 ] || fail "Provider non-zero exit should be non-blocking ESCALATE"
+  [ "$status" -ne 0 ] || fail "Provider non-zero exit should fail closed"
   jq -e '
     .provider == "heiyucode_claude_code"
     and .transport == "messages-api"
     and .model == "claude-heiyu-test"
     and .status == "error"
     and .error_type == "provider_error"
-    and .passed == true
+    and .passed == false
     and .escalate == true
     and .exit_code == 17
     and .stdout_bytes == 0
@@ -352,7 +465,7 @@ test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Non-zero provider diagnostics mismatch"
 }
 
-test_heiyucode_provider_empty_output_escalates_with_diagnostics() {
+test_heiyucode_provider_empty_output_fails_closed_with_diagnostics() {
   local tmp fake_bin calls status
   tmp="$(mktemp -d)"
   fake_bin="$tmp/bin"
@@ -377,14 +490,14 @@ test_heiyucode_provider_empty_output_escalates_with_diagnostics() {
   status="$?"
   set -e
 
-  [ "$status" -eq 0 ] || fail "Empty provider response should be non-blocking ESCALATE"
+  [ "$status" -ne 0 ] || fail "Empty provider response should fail closed"
   jq -e '
     .provider == "heiyucode_claude_code"
     and .transport == "messages-api"
     and .status == "error"
     and .error_type == "provider_error"
     and .reason == "No text in response"
-    and .passed == true
+    and .passed == false
     and .escalate == true
     and .exit_code == 0
     and .stdout_bytes == 0
@@ -394,7 +507,7 @@ test_heiyucode_provider_empty_output_escalates_with_diagnostics() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty output diagnostics mismatch"
 }
 
-test_heiyucode_provider_http_error_escalates_with_response_tail() {
+test_heiyucode_provider_http_error_fails_closed_with_response_tail() {
   local tmp fake_bin calls status
   tmp="$(mktemp -d)"
   fake_bin="$tmp/bin"
@@ -418,14 +531,14 @@ test_heiyucode_provider_http_error_escalates_with_response_tail() {
   status="$?"
   set -e
 
-  [ "$status" -eq 0 ] || fail "HTTP provider error should be non-blocking ESCALATE"
+  [ "$status" -ne 0 ] || fail "HTTP provider error should fail closed"
   jq -e '
     .provider == "heiyucode_claude_code"
     and .transport == "messages-api"
     and .status == "error"
     and .error_type == "provider_error"
     and .reason == "HeiyuCode Messages API HTTP 500"
-    and .passed == true
+    and .passed == false
     and .escalate == true
     and .http_status == "500"
     and .attempts == 2
@@ -578,16 +691,69 @@ SH
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Large prompt result metadata mismatch"
 }
 
+test_aggregate_includes_llm_review_failure() {
+  local tmp output code
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/results"
+  cat > "$tmp/results/d1-changelog.json" <<'JSON'
+{"check_id":"D-1","check_name":"CHANGELOG","passed":true,"issues":[]}
+JSON
+  cat > "$tmp/results/llm-review.json" <<'JSON'
+{"review_id":"llm-review","check_name":"LLM Review","provider":"anthropic","status":"error","reason":"API error","passed":false,"escalate":true}
+JSON
+
+  set +e
+  output=$(RESULTS_DIR="$tmp/results" REQUIRED_RESULT_FILES="d1-changelog.json" "$ROOT_DIR/scripts/aggregate.sh" 2>&1)
+  code=$?
+  set -e
+
+  [ "$code" -ne 0 ] || fail "Aggregator must fail when llm-review.json failed"
+  jq -e '.verdict.total_checks == 2 and .verdict.failed == 1 and (.results[] | select(.review_id == "llm-review" and .passed == false))' \
+    "$tmp/results/aggregate.json" >/dev/null || fail "Aggregator must include failed llm-review result"
+}
+
+test_aggregate_fails_closed_when_required_result_is_missing() {
+  local tmp output code
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/results"
+  cat > "$tmp/results/d1-changelog.json" <<'JSON'
+{"check_id":"D-1","check_name":"CHANGELOG","passed":true,"issues":[]}
+JSON
+
+  set +e
+  output=$(RESULTS_DIR="$tmp/results" REQUIRED_RESULT_FILES="d1-changelog.json d2-terminology.json" "$ROOT_DIR/scripts/aggregate.sh" 2>&1)
+  code=$?
+  set -e
+
+  [ "$code" -ne 0 ] || fail "Aggregator must fail when a required result file is missing"
+  jq -e '.verdict.failed == 1 and (.results[] | select(.check_id == "D-MISSING" and .passed == false and (.issues[] | contains("d2-terminology.json"))))' \
+    "$tmp/results/aggregate.json" >/dev/null || fail "Aggregator must materialize missing required result failure"
+}
+
+test_workflow_requires_llm_result_when_llm_enabled() {
+  local workflow
+  workflow="$(cat "$ROOT_DIR/.github/workflows/consistency-sentinel.yml")"
+  assert_contains "$workflow" "REQUIRED_RESULT_FILES="
+  assert_contains "$workflow" "llm-review.json"
+  assert_contains "$workflow" "inputs.skip_llm"
+}
+
 test_anthropic_provider_uses_messages_api
 test_request_body_uses_file_backed_payload_for_anthropic
 test_large_prompt_uses_file_backed_payload_without_arg_list_overflow
 test_heiyucode_provider_uses_messages_api
 test_heiyucode_provider_hard_fails_explicit_fail_verdict
-test_heiyucode_provider_timeout_escalates_without_waiting_for_job_timeout
-test_heiyucode_provider_nonzero_exit_escalates_with_diagnostics
-test_heiyucode_provider_empty_output_escalates_with_diagnostics
-test_heiyucode_provider_http_error_escalates_with_response_tail
+test_anthropic_api_error_fails_closed
+test_anthropic_empty_text_fails_closed
+test_heiyucode_provider_hard_fails_explicit_escalate_verdict
+test_heiyucode_provider_timeout_fails_closed_without_waiting_for_job_timeout
+test_heiyucode_provider_nonzero_exit_fails_closed_with_diagnostics
+test_heiyucode_provider_empty_output_fails_closed_with_diagnostics
+test_heiyucode_provider_http_error_fails_closed_with_response_tail
 test_heiyucode_provider_retries_retryable_524_once
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure
+test_aggregate_includes_llm_review_failure
+test_aggregate_fails_closed_when_required_result_is_missing
+test_workflow_requires_llm_result_when_llm_enabled
 
 echo "llm-review provider router tests passed"


### PR DESCRIPTION
## Scope

从冲突大 PR #60 中拆出 LLM fail-closed 子项，基于当前 main 重放。

## Changes

- LLM 审查启用后，unsupported provider、缺少凭证、provider API error、空响应、provider client error、JSON 解析失败和 ESCALATE verdict 都写入 failing llm-review result，并以非 0 退出。
- aggregate 纳入 llm-review result，并支持 REQUIRED_RESULT_FILES 将缺失结果物化为失败。
- reusable Consistency Sentinel 在 skip_llm 不为 true 时，把 llm-review.json 加入 required result list。
- 扩展 provider router 测试，覆盖 Anthropic API error、空响应、HeiyuCode timeout/nonzero/empty/http error、ESCALATE verdict、aggregate 和 workflow wiring。

## Verification

- bash tests/test-llm-review-provider-router.sh
- bash tests/test-policy-file.sh
- bash tests/test-d7-d8.sh
- bash tests/test-self-test-workflow.sh
- bash tests/test-caller-sync-workflow.sh
- bash tests/test-dashboard-workflow.sh
- bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh
- ruby workflow YAML parse
- git diff --check HEAD~1..HEAD

## Related

- Split from stale/conflicting #60.
- #91 landed self-test gate.
- #92 landed caller-sync boolean default.
- #93 landed D-7/D-8 empty-array noise cleanup.
- Remaining #60 scope after this: cascade fail-closed semantics.