### PR TITLE
[codex] fix(caller-sync): 刷新已有同步 PR 分支

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -148,9 +148,13 @@ jobs:
                 fi
 
                 EXISTING_PR=$(echo "$EXISTING_BODY" | jq 'length')
+                EXISTING_PR_NUMBER=$(echo "$EXISTING_BODY" | jq -r '.[0].number // empty')
+                EXISTING_PR_AUTOSYNC=$(echo "$EXISTING_BODY" \
+                  | jq -r '.[0] | select(((.title // "") == "chore(sentinel): sync caller workflow to latest template") or ((.body // "") | contains("sentinel-auto-sync"))) | .number // empty')
 
-                if [ "$EXISTING_PR" != "0" ]; then
-                  echo "Open sync PR already exists for ${REPO}, skipping."
+                if [ "$EXISTING_PR" != "0" ] && [ -z "$EXISTING_PR_AUTOSYNC" ]; then
+                  echo "Existing sentinel-caller-sync PR is not marked as auto-sync for ${REPO}"
+                  FAILED="${FAILED}${REPO}:existing_pr_not_autosync,"
                   echo "::endgroup::"
                   continue
                 fi
@@ -169,18 +173,48 @@ jobs:
                   continue
                 fi
 
-                # Create branch
-                CREATE_REF_RESULT=$(curl -s -o /tmp/create-ref-response.json -w "%{http_code}" -X POST \
-                  -H "Authorization: token ${GH_TOKEN}" \
-                  -H "Accept: application/vnd.github+json" \
-                  "https://api.github.com/repos/huanlongAI/${REPO}/git/refs" \
-                  -d "$(jq -n --arg sha "$DEFAULT_SHA" \
-                    '{ref: "refs/heads/sentinel-caller-sync", sha: $sha}')")
-                if [ "$CREATE_REF_RESULT" != "201" ] && [ "$CREATE_REF_RESULT" != "422" ]; then
-                  echo "Branch create failed (HTTP $CREATE_REF_RESULT) for ${REPO}"
-                  FAILED="${FAILED}${REPO}:create_ref_http_${CREATE_REF_RESULT},"
-                  echo "::endgroup::"
-                  continue
+                REFRESH_REF_RESULT=""
+
+                if [ "$EXISTING_PR" != "0" ]; then
+                  REFRESH_REF_RESULT=$(curl -s -o /tmp/refresh-ref-response.json -w "%{http_code}" -X PATCH \
+                    -H "Authorization: token ${GH_TOKEN}" \
+                    -H "Accept: application/vnd.github+json" \
+                    "https://api.github.com/repos/huanlongAI/${REPO}/git/refs/heads/sentinel-caller-sync" \
+                    -d "$(jq -n --arg sha "$DEFAULT_SHA" \
+                      '{sha: $sha, force: true}')")
+                  if [ "$REFRESH_REF_RESULT" != "200" ]; then
+                    echo "Branch refresh failed (HTTP $REFRESH_REF_RESULT) for ${REPO}"
+                    FAILED="${FAILED}${REPO}:refresh_ref_http_${REFRESH_REF_RESULT},"
+                    echo "::endgroup::"
+                    continue
+                  fi
+                else
+                  # Create branch, or reset an orphaned stale sync branch back to main.
+                  CREATE_REF_RESULT=$(curl -s -o /tmp/create-ref-response.json -w "%{http_code}" -X POST \
+                    -H "Authorization: token ${GH_TOKEN}" \
+                    -H "Accept: application/vnd.github+json" \
+                    "https://api.github.com/repos/huanlongAI/${REPO}/git/refs" \
+                    -d "$(jq -n --arg sha "$DEFAULT_SHA" \
+                      '{ref: "refs/heads/sentinel-caller-sync", sha: $sha}')")
+                  if [ "$CREATE_REF_RESULT" = "422" ]; then
+                    REFRESH_REF_RESULT=$(curl -s -o /tmp/refresh-ref-response.json -w "%{http_code}" -X PATCH \
+                      -H "Authorization: token ${GH_TOKEN}" \
+                      -H "Accept: application/vnd.github+json" \
+                      "https://api.github.com/repos/huanlongAI/${REPO}/git/refs/heads/sentinel-caller-sync" \
+                      -d "$(jq -n --arg sha "$DEFAULT_SHA" \
+                        '{sha: $sha, force: true}')")
+                    if [ "$REFRESH_REF_RESULT" != "200" ]; then
+                      echo "Branch refresh failed (HTTP $REFRESH_REF_RESULT) for ${REPO}"
+                      FAILED="${FAILED}${REPO}:refresh_ref_http_${REFRESH_REF_RESULT},"
+                      echo "::endgroup::"
+                      continue
+                    fi
+                  elif [ "$CREATE_REF_RESULT" != "201" ]; then
+                    echo "Branch create failed (HTTP $CREATE_REF_RESULT) for ${REPO}"
+                    FAILED="${FAILED}${REPO}:create_ref_http_${CREATE_REF_RESULT},"
+                    echo "::endgroup::"
+                    continue
+                  fi
                 fi
 
                 # Get current file SHA for update
@@ -204,27 +238,31 @@ jobs:
                     '{message: $msg, content: $content, sha: $sha, branch: $branch}')")
 
                 if [ "$UPDATE_RESULT" = "200" ] || [ "$UPDATE_RESULT" = "201" ]; then
-                  # Create PR
-                  PR_RESP=$(curl -s -w "\n%{http_code}" -X POST \
-                    -H "Authorization: token ${GH_TOKEN}" \
-                    -H "Accept: application/vnd.github+json" \
-                    "https://api.github.com/repos/huanlongAI/${REPO}/pulls" \
-                    -d "$(jq -n \
-                      --arg title "chore(sentinel): sync caller workflow to latest template" \
-                      --arg body "Auto-generated by sentinel caller-sync workflow.\n\nThe caller workflow in this repo has drifted from the canonical template in sentinel-shared. This PR updates it to match.\n\nLabel: sentinel-auto-sync" \
-                      --arg head "sentinel-caller-sync" \
-                      --arg base "main" \
-                      '{title: $title, body: $body, head: $head, base: $base}')")
-                  PR_HTTP=$(echo "$PR_RESP" | tail -1)
-                  PR_BODY=$(echo "$PR_RESP" | sed '$d')
-                  PR_URL=$(echo "$PR_BODY" | jq -r '.html_url // empty')
-                  if [ "$PR_HTTP" != "201" ] || [ -z "$PR_URL" ]; then
-                    echo "PR create failed (HTTP $PR_HTTP) for ${REPO}"
-                    FAILED="${FAILED}${REPO}:create_pr_http_${PR_HTTP},"
-                    echo "::endgroup::"
-                    continue
+                  if [ "$EXISTING_PR" != "0" ]; then
+                    echo "Existing sync PR refreshed: #${EXISTING_PR_NUMBER}"
+                  else
+                    # Create PR
+                    PR_RESP=$(curl -s -w "\n%{http_code}" -X POST \
+                      -H "Authorization: token ${GH_TOKEN}" \
+                      -H "Accept: application/vnd.github+json" \
+                      "https://api.github.com/repos/huanlongAI/${REPO}/pulls" \
+                      -d "$(jq -n \
+                        --arg title "chore(sentinel): sync caller workflow to latest template" \
+                        --arg body "Auto-generated by sentinel caller-sync workflow.\n\nThe caller workflow in this repo has drifted from the canonical template in sentinel-shared. This PR updates it to match.\n\nLabel: sentinel-auto-sync" \
+                        --arg head "sentinel-caller-sync" \
+                        --arg base "main" \
+                        '{title: $title, body: $body, head: $head, base: $base}')")
+                    PR_HTTP=$(echo "$PR_RESP" | tail -1)
+                    PR_BODY=$(echo "$PR_RESP" | sed '$d')
+                    PR_URL=$(echo "$PR_BODY" | jq -r '.html_url // empty')
+                    if [ "$PR_HTTP" != "201" ] || [ -z "$PR_URL" ]; then
+                      echo "PR create failed (HTTP $PR_HTTP) for ${REPO}"
+                      FAILED="${FAILED}${REPO}:create_pr_http_${PR_HTTP},"
+                      echo "::endgroup::"
+                      continue
+                    fi
+                    echo "PR created: $PR_URL"
                   fi
-                  echo "PR created: $PR_URL"
                 else
                   echo "File update failed (HTTP $UPDATE_RESULT) for ${REPO}"
                   FAILED="${FAILED}${REPO}:update_http_${UPDATE_RESULT},"

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -26,10 +26,21 @@ if [ "$count" -ne 2 ]; then
   fail "caller-sync should default scheduled runs to dry_run=true while preserving workflow_dispatch dry_run=false"
 fi
 
+if grep -q 'Open sync PR already exists for ${REPO}, skipping.' "$CALLER_SYNC_WORKFLOW"; then
+  fail "caller-sync must refresh existing sentinel-caller-sync PR branches instead of skipping them"
+fi
+
 for expected in \
   'FAILED=""' \
   'failed_count=' \
   'head=huanlongAI:sentinel-caller-sync' \
+  'EXISTING_PR_NUMBER=' \
+  'EXISTING_PR_AUTOSYNC=' \
+  'existing_pr_not_autosync' \
+  'REFRESH_REF_RESULT=' \
+  'Branch refresh failed' \
+  'Existing sync PR refreshed' \
+  'force: true' \
   'File update failed' \
   'exit 1'
 do


### PR DESCRIPTION
## 变更

- caller-sync live 模式遇到已有 `sentinel-caller-sync` 自动同步 PR 时，不再跳过旧 PR。
- 将已有自动同步分支刷新到当前 main，再写入最新 canonical caller workflow。
- 同名 PR 不是自动同步 PR、刷新分支失败、更新文件失败时继续登记 FAILED，并由 live sync fail closed。

## 根因

旧实现看到已有 open `sentinel-caller-sync` PR 就直接跳过，导致模板继续演进后旧 PR 停留在过期 head，后续出现 BEHIND / CONFLICTING，caller-sync 不能完成批量收口。

## 验证

- `bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-self-test-workflow.sh`
- `bash tests/test-agent-governance.sh`
- `bash tests/test-policy-file.sh`
- `bash tests/test-d7-d8.sh`
- `bash tests/test-dashboard-workflow.sh`
- `bash tests/test-cascade-workflow.sh`
- `bash tests/test-llm-review-provider-router.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- Ruby YAML parse for `.github/workflows/*.yml`
- `git diff --check`