### PR TITLE
[codex] fix(caller-sync): 支持按仓库范围同步

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: true
         type: boolean
+      target_repos:
+        description: Optional space-separated downstream repo subset
+        required: false
+        default: ''
+        type: string
   schedule:
     - cron: '0 0 * * 0'
 
@@ -67,7 +72,46 @@ jobs:
           SKIPPED=""
           FAILED=""
           DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
+          TARGET_REPOS_INPUT="${{ github.event.inputs.target_repos || '' }}"
+          SELECTED_REPOS=""
+          INVALID_TARGETS=""
           REPORT=""
+
+          if [ -z "$TARGET_REPOS_INPUT" ]; then
+            SELECTED_REPOS="$DOWNSTREAM_REPOS"
+          else
+            for REQUESTED_REPO in $TARGET_REPOS_INPUT; do
+              case " $DOWNSTREAM_REPOS " in
+                *" $REQUESTED_REPO "*)
+                  SELECTED_REPOS="${SELECTED_REPOS}${REQUESTED_REPO} "
+                  ;;
+                *)
+                  INVALID_TARGETS="${INVALID_TARGETS}${REQUESTED_REPO},"
+                  ;;
+              esac
+            done
+          fi
+
+          if [ -n "$INVALID_TARGETS" ]; then
+            FAILED="invalid_target:${INVALID_TARGETS%,},"
+            echo "::error::Invalid caller-sync target(s): ${INVALID_TARGETS%,}"
+            echo "drifted=" >> "$GITHUB_OUTPUT"
+            echo "drift_count=0" >> "$GITHUB_OUTPUT"
+            echo "synced=" >> "$GITHUB_OUTPUT"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+            echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+            echo "failed_count=1" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Caller Workflow Sync Report"
+              echo ""
+              echo "Mode: $( [ "$DRY_RUN" = "true" ] && echo 'DRY RUN (preview only)' || echo 'LIVE (PRs created)')"
+              echo "Targets: ${TARGET_REPOS_INPUT}"
+              echo "Synced: 0 | Drifted: 0 | Missing: 0 | Failed: 1"
+              echo ""
+              echo "Failed targets: ${FAILED%,}"
+            } > /tmp/sync-report.md
+            exit 0
+          fi
 
           gha_expr() {
             printf '$''{{ %s }}' "$1"
@@ -88,7 +132,7 @@ jobs:
             | grep -v '^$' \
             | sort)
 
-          for REPO in $DOWNSTREAM_REPOS; do
+          for REPO in $SELECTED_REPOS; do
             echo "::group::Checking ${REPO}"
 
             # Fetch current caller workflow
@@ -291,7 +335,8 @@ jobs:
           {
             echo "## Caller Workflow Sync Report"
             echo ""
-            echo "Mode: $( [ '$DRY_RUN' = 'true' ] && echo 'DRY RUN (preview only)' || echo 'LIVE (PRs created)')"
+            echo "Mode: $( [ "$DRY_RUN" = "true" ] && echo 'DRY RUN (preview only)' || echo 'LIVE (PRs created)')"
+            echo "Targets: ${SELECTED_REPOS}"
             echo "Synced: ${SYNC_COUNT} | Drifted: ${DRIFT_COUNT} | Missing: ${MISS_COUNT} | Failed: ${FAIL_COUNT}"
             if [ "$FAIL_COUNT" != "0" ]; then
               echo ""

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -30,7 +30,18 @@ if grep -q 'Open sync PR already exists for ${REPO}, skipping.' "$CALLER_SYNC_WO
   fail "caller-sync must refresh existing sentinel-caller-sync PR branches instead of skipping them"
 fi
 
+if grep -Fq "[ '\$DRY_RUN' = 'true' ]" "$CALLER_SYNC_WORKFLOW"; then
+  fail "caller-sync summary must evaluate DRY_RUN value instead of the literal string"
+fi
+
 for expected in \
+  'target_repos:' \
+  'TARGET_REPOS_INPUT=' \
+  'SELECTED_REPOS=' \
+  'INVALID_TARGETS=' \
+  'invalid_target' \
+  'for REPO in $SELECTED_REPOS' \
+  '[ "$DRY_RUN" = "true" ]' \
   'FAILED=""' \
   'failed_count=' \
   'head=huanlongAI:sentinel-caller-sync' \


### PR DESCRIPTION
## 变更

- 为 `caller-sync.yml` 增加 `target_repos` workflow_dispatch 输入，支持按空格分隔的 downstream repo 子集执行。
- 空输入保持原有全量 17 仓行为；非空输入只遍历 allowlist 中的目标。
- 非法 target 记录 `invalid_target`，写入 failed outputs，并在 live 模式继续 fail closed。
- 修正 step summary 中 dry-run/live Mode 判断，避免把 dry-run 误报为 LIVE。

## 原因

#98 合并后，caller-sync 已能刷新旧自动同步 PR，但 workflow 仍只能全量扫描/写入 17 仓。NODE-E 当前不应在未明确跨域授权时触发会写入 Huanlong 以外仓库的 live run，因此需要 scoped target 能力先落地。

## 验证

本轮 push 前已重新执行：

- `bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-self-test-workflow.sh`
- `bash tests/test-agent-governance.sh`
- Ruby YAML parse for `.github/workflows/*.yml`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- `git diff --check`

上一轮本地扩展验证还覆盖了 policy / D-7-D-8 / dashboard / cascade / llm-router。