### PR TITLE
[codex] 兼容旧 caller-sync PR 标记

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -194,7 +194,11 @@ jobs:
                 EXISTING_PR=$(echo "$EXISTING_BODY" | jq 'length')
                 EXISTING_PR_NUMBER=$(echo "$EXISTING_BODY" | jq -r '.[0].number // empty')
                 EXISTING_PR_AUTOSYNC=$(echo "$EXISTING_BODY" \
-                  | jq -r '.[0] | select(((.title // "") == "chore(sentinel): sync caller workflow to latest template") or ((.body // "") | contains("sentinel-auto-sync"))) | .number // empty')
+                  | jq -r '.[0] | select(
+                    ((.title // "") == "chore(sentinel): sync caller workflow to latest template")
+                    or ((.body // "") | contains("sentinel-auto-sync"))
+                    or (((.title // "") | startswith("chore(sentinel):")) and ((.body // "") | contains("huanlongAI/sentinel-shared#17")))
+                  ) | .number // empty')
 
                 if [ "$EXISTING_PR" != "0" ] && [ -z "$EXISTING_PR_AUTOSYNC" ]; then
                   echo "Existing sentinel-caller-sync PR is not marked as auto-sync for ${REPO}"

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -47,6 +47,8 @@ for expected in \
   'head=huanlongAI:sentinel-caller-sync' \
   'EXISTING_PR_NUMBER=' \
   'EXISTING_PR_AUTOSYNC=' \
+  'huanlongAI/sentinel-shared#17' \
+  'startswith("chore(sentinel):")' \
   'existing_pr_not_autosync' \
   'REFRESH_REF_RESULT=' \
   'Branch refresh failed' \


### PR DESCRIPTION
## 背景

#17 的 Huanlong live caller-sync run 在 scoped 模式下 fail closed，原因是 2026-05-27 手动生成的旧 `sentinel-caller-sync` PR 没有 #98 新增的 `sentinel-auto-sync` marker，导致刷新逻辑判定为 `existing_pr_not_autosync`。

## 变更

- 保持非自动同步同名 PR fail closed。
- 兼容旧 caller-sync PR：标题以 `chore(sentinel):` 开头且正文关联 `huanlongAI/sentinel-shared#17` 时，允许刷新现有 `sentinel-caller-sync` 分支。
- 增加测试守卫，确保旧 #17 caller-sync PR marker 被识别。

## 验证

- `bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-owner-reviewed-override.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- Ruby YAML parse for `.github/workflows/*.yml`
- `git diff --check`

## 后续

PR 合并后，可重新触发 caller-sync live run，范围仍建议限定 Huanlong drift 目标。