### PR TITLE
chore(caller-sync): retain canonical workflow comments

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -25,6 +25,13 @@ env:
     hl-platform hl-framework hl-factory hl-dispatch hl-contracts hl-console-native team-memory
 
   CANONICAL_BODY: |
+    # ============================================================================
+    # Consistency Sentinel -- MIRA P-2 Consistency Gate
+    # Phase 1: Caller template -> huanlongAI/sentinel-shared reusable workflow
+    # NOTE: permissions MUST be in caller, not in reusable workflow
+    # The @main reusable workflow reference is intentional for this thin caller projection.
+    # Compatibility is governed by sentinel-shared cascade, D-10, and caller-sync drift checks.
+    # ============================================================================
     name: Consistency Sentinel
     on:
       pull_request:
@@ -48,6 +55,8 @@ env:
       sentinel:
         uses: huanlongAI/sentinel-shared/.github/workflows/consistency-sentinel.yml@main
         secrets:
+          # LLM provider credentials are consumed only by sentinel-shared provider router.
+          # HeiyuCode is preferred when configured; Anthropic remains the fallback provider.
           ANTHROPIC_API_KEY: __EXPR_ANTHROPIC_API_KEY__
           HEIYUCODE_AUTH_TOKEN: __EXPR_HEIYUCODE_AUTH_TOKEN__
           HEIYUCODE_API_KEY: __EXPR_HEIYUCODE_API_KEY__

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -35,6 +35,11 @@ if grep -Fq "[ '\$DRY_RUN' = 'true' ]" "$CALLER_SYNC_WORKFLOW"; then
 fi
 
 for expected in \
+  'Consistency Sentinel -- MIRA P-2 Consistency Gate' \
+  'NOTE: permissions MUST be in caller, not in reusable workflow' \
+  '@main reusable workflow reference is intentional for this thin caller projection.' \
+  'LLM provider credentials are consumed only by sentinel-shared provider router.' \
+  'HeiyuCode is preferred when configured; Anthropic remains the fallback provider.' \
   'target_repos:' \
   'TARGET_REPOS_INPUT=' \
   'SELECTED_REPOS=' \


### PR DESCRIPTION
## 变更

- 在 caller-sync 的 canonical caller workflow 中恢复并保留说明性注释。
- 明确 caller 权限边界、sentinel-shared @main 薄投影语义、LLM provider secrets 路由。
- 给 test-caller-sync-workflow 增加注释保留断言，防止后续同步模板再次删注释。

## 背景

下游手工同步 PR 中，LLM review 将纯 caller workflow 同步判为 DBC-002 文档退化，并对 @main 引用产生 SAC-004 不确定升级。这个问题不应通过逐仓漂移文档来绕过，而应回到 canonical 模板补足说明。

关联：huanlongAI/sentinel-shared#17

## 验证

- bash tests/test-caller-sync-workflow.sh
- bash tests/test-owner-reviewed-override.sh
- bash tests/test-llm-review-provider-router.sh
- bash tests/test-self-test-workflow.sh
- bash tests/test-cascade-workflow.sh