### PR TITLE
fix(cascade): 等待下游 run 完成后再汇总

### DIFF
--- a/.github/workflows/cascade-verify.yml
+++ b/.github/workflows/cascade-verify.yml
@@ -112,52 +112,65 @@ jobs:
     steps:
       - name: Wait for downstream workflows
         run: |
-          echo "Waiting 120s for downstream sentinel runs to start and complete..."
-          sleep 120
+          echo "Waiting briefly for downstream sentinel runs to start..."
+          sleep 20
 
       - name: Collect downstream results
         id: results
         env:
           GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
         run: |
-          PASS=0
-          FAIL=0
-          SKIP=0
-          REPORT=""
+          CASCADE_WAIT_TIMEOUT_SECONDS="${CASCADE_WAIT_TIMEOUT_SECONDS:-900}"
+          CASCADE_POLL_INTERVAL_SECONDS="${CASCADE_POLL_INTERVAL_SECONDS:-20}"
           DISPATCH_FAILED="${{ needs.fan-out.outputs.failed }}"
           TRIGGER_TIME="${{ needs.fan-out.outputs.triggered && 'set' || 'unset' }}"
+          deadline=$((SECONDS + CASCADE_WAIT_TIMEOUT_SECONDS))
 
-          for REPO in $DOWNSTREAM_REPOS; do
-            # Get the most recent sentinel workflow run
-            RUN_DATA=$(curl -s \
-              -H "Authorization: token ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/huanlongAI/${REPO}/actions/runs?per_page=3&event=repository_dispatch" \
-              | jq -r '.workflow_runs[0] // empty')
+          while true; do
+            PASS=0
+            FAIL=0
+            SKIP=0
+            REPORT=""
 
-            if [ -z "$RUN_DATA" ]; then
-              REPORT="${REPORT}| ${REPO} | ⏭️ skip | No dispatch run found |\n"
-              SKIP=$((SKIP + 1))
-              continue
+            for REPO in $DOWNSTREAM_REPOS; do
+              # Get the most recent sentinel workflow run
+              RUN_DATA=$(curl -s \
+                -H "Authorization: token ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/huanlongAI/${REPO}/actions/runs?per_page=3&event=repository_dispatch" \
+                | jq -r '.workflow_runs[0] // empty')
+
+              if [ -z "$RUN_DATA" ]; then
+                REPORT="${REPORT}| ${REPO} | ⏭️ skip | No dispatch run found |\n"
+                SKIP=$((SKIP + 1))
+                continue
+              fi
+
+              CONCLUSION=$(echo "$RUN_DATA" | jq -r '.conclusion // "pending"')
+              RUN_URL=$(echo "$RUN_DATA" | jq -r '.html_url // "N/A"')
+
+              case "$CONCLUSION" in
+                success)
+                  REPORT="${REPORT}| ${REPO} | ✅ pass | [Run](${RUN_URL}) |\n"
+                  PASS=$((PASS + 1))
+                  ;;
+                failure)
+                  REPORT="${REPORT}| ${REPO} | ❌ fail | [Run](${RUN_URL}) |\n"
+                  FAIL=$((FAIL + 1))
+                  ;;
+                *)
+                  REPORT="${REPORT}| ${REPO} | ⏳ ${CONCLUSION} | [Run](${RUN_URL}) |\n"
+                  SKIP=$((SKIP + 1))
+                  ;;
+              esac
+            done
+
+            echo "Cascade poll: pass=${PASS}, fail=${FAIL}, skip=${SKIP}"
+            if [ "$SKIP" -eq 0 ] || [ "$SECONDS" -ge "$deadline" ]; then
+              break
             fi
 
-            CONCLUSION=$(echo "$RUN_DATA" | jq -r '.conclusion // "pending"')
-            RUN_URL=$(echo "$RUN_DATA" | jq -r '.html_url // "N/A"')
-
-            case "$CONCLUSION" in
-              success)
-                REPORT="${REPORT}| ${REPO} | ✅ pass | [Run](${RUN_URL}) |\n"
-                PASS=$((PASS + 1))
-                ;;
-              failure)
-                REPORT="${REPORT}| ${REPO} | ❌ fail | [Run](${RUN_URL}) |\n"
-                FAIL=$((FAIL + 1))
-                ;;
-              *)
-                REPORT="${REPORT}| ${REPO} | ⏳ ${CONCLUSION} | [Run](${RUN_URL}) |\n"
-                SKIP=$((SKIP + 1))
-                ;;
-            esac
+            sleep "$CASCADE_POLL_INTERVAL_SECONDS"
           done
 
           echo "pass=${PASS}" >> "$GITHUB_OUTPUT"

--- a/tests/test-cascade-workflow.sh
+++ b/tests/test-cascade-workflow.sh
@@ -26,6 +26,11 @@ workflow="$(cat "$WORKFLOW")"
 assert_contains "$workflow" "::error::Some dispatches failed:"
 assert_contains "$workflow" 'exit 1'
 assert_contains "$workflow" 'DISPATCH_FAILED="${{ needs.fan-out.outputs.failed }}"'
+assert_contains "$workflow" 'CASCADE_WAIT_TIMEOUT_SECONDS="${CASCADE_WAIT_TIMEOUT_SECONDS:-900}"'
+assert_contains "$workflow" 'CASCADE_POLL_INTERVAL_SECONDS="${CASCADE_POLL_INTERVAL_SECONDS:-20}"'
+assert_contains "$workflow" 'deadline=$((SECONDS + CASCADE_WAIT_TIMEOUT_SECONDS))'
+assert_contains "$workflow" 'while true; do'
+assert_contains "$workflow" 'if [ "$SKIP" -eq 0 ] || [ "$SECONDS" -ge "$deadline" ]; then'
 assert_contains "$workflow" 'if [ -n "$DISPATCH_FAILED" ] || [ "$FAIL" -gt 0 ] || [ "$SKIP" -gt 0 ]; then'
 assert_contains "$workflow" '::error::Cascade verification incomplete or failed:'
 assert_contains "$workflow" "always() && (steps.results.outputs.fail != '0' || steps.results.outputs.skip != '0' || needs.fan-out.outputs.failed != '')"


### PR DESCRIPTION
## Summary

修复 `Cascade Verification` 在下游 repository_dispatch run 尚未完成时过早采样，导致 `skip/pending` 被误判为失败的问题。

## Changes

- 将固定 `sleep 120` 后单次汇总改为 bounded polling。
- 默认最多等待 900 秒，每 20 秒重新采样 downstream run 状态。
- 保持 fail-closed：dispatch failure、真实 failure、超时后仍 pending 都会继续失败并创建 issue。
- 增加 workflow shape 回归测试，锁定 polling 结构。

## Verification

- RED: `bash tests/test-cascade-workflow.sh` 先因缺少 `CASCADE_WAIT_TIMEOUT_SECONDS` 断言失败。
- GREEN: `bash tests/test-cascade-workflow.sh` 通过。
- `for t in tests/*.sh; do bash "$t"; done` 全部通过。
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh` 通过。
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'` 通过。\n- `git diff --check` 通过。\n