### PR TITLE
fix(caller-sync): cascade 触发时跳过 LLM

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -129,7 +129,7 @@ jobs:
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_ANTHROPIC_API_KEY__/$(gha_expr 'secrets.ANTHROPIC_API_KEY')}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_AUTH_TOKEN__/$(gha_expr 'secrets.HEIYUCODE_AUTH_TOKEN')}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_API_KEY__/$(gha_expr 'secrets.HEIYUCODE_API_KEY')}"
-          CANONICAL_BODY="${CANONICAL_BODY//__EXPR_SKIP_LLM__/$(gha_expr "fromJSON(github.event.inputs.skip_llm || 'false')")}"
+          CANONICAL_BODY="${CANONICAL_BODY//__EXPR_SKIP_LLM__/$(gha_expr "github.event_name == 'repository_dispatch' || fromJSON(github.event.inputs.skip_llm || 'false')")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_BASE_URL__/$(gha_expr "vars.HEIYUCODE_BASE_URL || 'https://www.heiyucode.com'")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_MODEL__/$(gha_expr "vars.HEIYUCODE_MODEL || ''")}"
 

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -21,6 +21,9 @@ if grep -q "default: 'false'" "$CALLER_SYNC_WORKFLOW"; then
   fail "caller-sync canonical skip_llm boolean input default must stay boolean false, not string 'false'"
 fi
 
+grep -Fq "github.event_name == 'repository_dispatch' || fromJSON(github.event.inputs.skip_llm || 'false')" "$CALLER_SYNC_WORKFLOW" \
+  || fail "caller-sync canonical template must skip LLM during sentinel-cascade repository_dispatch"
+
 count="$(grep -c "github.event.inputs.dry_run || 'true'" "$CALLER_SYNC_WORKFLOW" || true)"
 if [ "$count" -ne 2 ]; then
   fail "caller-sync should default scheduled runs to dry_run=true while preserving workflow_dispatch dry_run=false"


### PR DESCRIPTION
## Summary

修复 sentinel caller canonical template：当调用来自 `repository_dispatch` / `sentinel-cascade` 时自动 `skip_llm=true`，让全量 cascade 专注 deterministic gates。PR / push / manual workflow_dispatch 仍保留 LLM 审查。

## Root Cause

全量 cascade 在 `tzhOS` 上失败为 `ESCALATE`：确定性检查通过，但 LLM 因 `RULINGS.md` 过大无法完成 GPC-003 比对。cascade 是跨仓健康验证，不应被不稳定的大上下文 LLM 审查阻断。

## Changes

- 更新 caller-sync canonical `skip_llm` 表达式：`github.event_name == 'repository_dispatch' || fromJSON(github.event.inputs.skip_llm || 'false')`。\n- 增加 caller-sync shape test，锁定 sentinel-cascade 自动跳过 LLM 的投影规则。\n\n## Verification\n\n- RED: `bash tests/test-caller-sync-workflow.sh` 先因缺少 cascade skip LLM 断言失败。\n- GREEN: `bash tests/test-caller-sync-workflow.sh` 通过。\n- `for t in tests/*.sh; do bash "$t"; done` 全部通过。\n- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh` 通过。\n- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'` 通过。\n- `git diff --check` 通过。\n