### PR TITLE
fix(owner-override): 识别 Founder 治理裁决

### DIFF
--- a/scripts/owner-reviewed-override.sh
+++ b/scripts/owner-reviewed-override.sh
@@ -11,6 +11,7 @@ REQUIRED_DETERMINISTIC_RESULT_FILES="${REQUIRED_DETERMINISTIC_RESULT_FILES:-}"
 OWNER_REVIEWED_COMMENTS_FILE="${OWNER_REVIEWED_COMMENTS_FILE:-}"
 PR_NUMBER="${PR_NUMBER:-}"
 HEAD_SHA="${HEAD_SHA:-}"
+HEAD_COMMIT_EPOCH="${HEAD_COMMIT_EPOCH:-}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -85,6 +86,11 @@ else
 fi
 
 actors_json=$(printf '%s\n' "$actors" | jq -R . | jq -s .)
+
+if [ -z "$HEAD_COMMIT_EPOCH" ]; then
+  HEAD_COMMIT_EPOCH=$(git show -s --format=%ct "$HEAD_SHA" 2>/dev/null || true)
+fi
+
 match=$(
   jq -r \
     --arg head "$HEAD_SHA" \
@@ -103,17 +109,47 @@ match=$(
       | select(.body | test("deterministic[ _-]*checks:[[:space:]]*PASS"; "i"))
       | select(.body | test("llm[-_ ]?review:[[:space:]]*ESCALATE"; "i"))
       | select(.body | test("follow[-_ ]?up:[[:space:]]*https://"; "i"))
-      | [.login, .association, .url]
+      | [.login, .association, .url, "structured_head_sha"]
       | @tsv
     ' <<< "$comments_json" 2>/dev/null | head -n 1
 )
+
+if [ -z "$match" ] && [ -n "$HEAD_COMMIT_EPOCH" ]; then
+  match=$(
+    jq -r \
+      --argjson actors "$actors_json" \
+      --argjson head_epoch "$HEAD_COMMIT_EPOCH" \
+      '
+        .[]
+        | {
+            body: (.body // ""),
+            login: (.user.login // .author.login // ""),
+            association: (.author_association // .authorAssociation // ""),
+            created_at: (.created_at // .createdAt // ""),
+            url: (.html_url // .url // "")
+          }
+        | select(.login as $login | $actors | index($login))
+        | select(((.created_at | fromdateiso8601? // 0) >= $head_epoch))
+        | select(.body | test("Founder[[:space:]]*裁决"; "i"))
+        | select(.body | test("owner-reviewed governance evidence|governance owner verification|负责人已审治理证据|治理负责人确认"; "i"))
+        | select(.body | test("deterministic[ _-]*checks|D-1"; "i"))
+        | select(.body | test("PASS"; "i"))
+        | select(.body | test("llm[-_ ]?review"; "i"))
+        | select(.body | test("ESCALATE"; "i"))
+        | select(.body | test("runtime_authorization[[:space:]]*=[[:space:]]*false"; "i"))
+        | select(.body | test("engineering_start[[:space:]]*=[[:space:]]*forbidden"; "i"))
+        | [.login, .association, .url, "founder_governance_ruling"]
+        | @tsv
+      ' <<< "$comments_json" 2>/dev/null | head -n 1
+  )
+fi
 
 if [ -z "$match" ]; then
   echo "No valid owner-reviewed override comment found"
   exit 0
 fi
 
-IFS=$'\t' read -r actor author_association comment_url <<< "$match"
+IFS=$'\t' read -r actor author_association comment_url override_source <<< "$match"
 
 jq -n \
   --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -121,11 +157,13 @@ jq -n \
   --arg actor "$actor" \
   --arg author_association "$author_association" \
   --arg comment_url "$comment_url" \
+  --arg override_source "$override_source" \
   '{
     review_id: "owner-reviewed-override",
     check_name: "Owner Reviewed Override",
     status: "accepted",
     passed: true,
+    override_source: $override_source,
     overrides_review_id: "llm-review",
     overrides_verdict: "ESCALATE",
     scope: "llm-review",

--- a/tests/test-owner-reviewed-override.sh
+++ b/tests/test-owner-reviewed-override.sh
@@ -63,6 +63,21 @@ write_comments_with_unstructured_head_mention() {
 JSON
 }
 
+write_founder_ruling_comments() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+[
+  {
+    "body": "## Founder 裁决：#92 owner-reviewed governance evidence\n\n裁决项：Q-HLCONTRACTS-92-GOVERNANCE-EVIDENCE-001 = A\n\n结论：\n\n- 认可 #92 当前 deterministic checks（确定性检查）结果作为 owner-reviewed governance evidence（负责人已审治理证据）：\n  - D-1 / D-2 / D-3 / D-4 / D-5 / D-6 / D-10：PASS。\n- sentinel / 一致性检查 当前 FAILURE 的实际原因仅为 llm-review = ESCALATE。\n- 本裁决即为 GitHub SSOT（唯一事实源）中的 governance owner verification（治理负责人确认）。\n\n边界：\n\n- runtime_authorization = false\n- engineering_start = forbidden\n\n后续处理：\n\n- 不因 llm-review = ESCALATE 继续追加无实质治理差异的文档改动。",
+    "user": {"login": "gate-owner"},
+    "author_association": "OWNER",
+    "created_at": "2026-06-03T09:34:15Z",
+    "html_url": "https://github.com/huanlongAI/hl-contracts/pull/92#issuecomment-founder"
+  }
+]
+JSON
+}
+
 test_owner_reviewed_override_accepts_exact_head_sha_owner_comment() {
   local tmp head_sha
   tmp="$(mktemp -d)"
@@ -159,6 +174,75 @@ YAML
     fail "owner-reviewed override must require structured head/head_sha evidence"
 }
 
+test_owner_reviewed_override_accepts_founder_ruling_after_head_commit() {
+  local tmp head_sha
+  tmp="$(mktemp -d)"
+  head_sha="ffffffffffffffffffffffffffffffffffffffff"
+  mkdir -p "$tmp/repo/.sentinel/results"
+  cat > "$tmp/repo/.sentinel/config.yaml" <<'YAML'
+owner_reviewed_override_actors:
+  - gate-owner
+YAML
+  write_passed_result "$tmp/repo/.sentinel/results/d1-changelog.json" "D-1" "CHANGELOG"
+  write_escalate_llm_result "$tmp/repo/.sentinel/results/llm-review.json"
+  write_founder_ruling_comments "$tmp/comments.json"
+
+  (
+    cd "$tmp/repo"
+    CONFIG_FILE=".sentinel/config.yaml" \
+      RESULTS_DIR=".sentinel/results" \
+      REQUIRED_DETERMINISTIC_RESULT_FILES="d1-changelog.json" \
+      OWNER_REVIEWED_COMMENTS_FILE="$tmp/comments.json" \
+      GITHUB_REPOSITORY="huanlongAI/hl-contracts" \
+      PR_NUMBER="92" \
+      HEAD_SHA="$head_sha" \
+      HEAD_COMMIT_EPOCH="1780477200" \
+      "$ROOT_DIR/scripts/owner-reviewed-override.sh"
+  )
+
+  jq -e '
+    .review_id == "owner-reviewed-override"
+    and .passed == true
+    and .status == "accepted"
+    and .override_source == "founder_governance_ruling"
+    and .overrides_review_id == "llm-review"
+    and .overrides_verdict == "ESCALATE"
+    and .head_sha == "'"$head_sha"'"
+    and .actor == "gate-owner"
+  ' "$tmp/repo/.sentinel/results/owner-reviewed-override.json" >/dev/null ||
+    fail "founder governance ruling after head commit was not accepted"
+}
+
+test_owner_reviewed_override_rejects_founder_ruling_before_head_commit() {
+  local tmp head_sha
+  tmp="$(mktemp -d)"
+  head_sha="9999999999999999999999999999999999999999"
+  mkdir -p "$tmp/repo/.sentinel/results"
+  cat > "$tmp/repo/.sentinel/config.yaml" <<'YAML'
+owner_reviewed_override_actors:
+  - gate-owner
+YAML
+  write_passed_result "$tmp/repo/.sentinel/results/d1-changelog.json" "D-1" "CHANGELOG"
+  write_escalate_llm_result "$tmp/repo/.sentinel/results/llm-review.json"
+  write_founder_ruling_comments "$tmp/comments.json"
+
+  (
+    cd "$tmp/repo"
+    CONFIG_FILE=".sentinel/config.yaml" \
+      RESULTS_DIR=".sentinel/results" \
+      REQUIRED_DETERMINISTIC_RESULT_FILES="d1-changelog.json" \
+      OWNER_REVIEWED_COMMENTS_FILE="$tmp/comments.json" \
+      GITHUB_REPOSITORY="huanlongAI/hl-contracts" \
+      PR_NUMBER="92" \
+      HEAD_SHA="$head_sha" \
+      HEAD_COMMIT_EPOCH="1780480800" \
+      "$ROOT_DIR/scripts/owner-reviewed-override.sh"
+  )
+
+  [ ! -f "$tmp/repo/.sentinel/results/owner-reviewed-override.json" ] ||
+    fail "founder governance ruling before head commit must not create override evidence"
+}
+
 test_aggregate_treats_llm_escalate_with_owner_override_as_owner_reviewed_pass() {
   local tmp output code
   tmp="$(mktemp -d)"
@@ -214,6 +298,8 @@ test_owner_reviewed_workflow_shape() {
 test_owner_reviewed_override_accepts_exact_head_sha_owner_comment
 test_owner_reviewed_override_rejects_stale_head_sha_comment
 test_owner_reviewed_override_requires_structured_head_sha_field
+test_owner_reviewed_override_accepts_founder_ruling_after_head_commit
+test_owner_reviewed_override_rejects_founder_ruling_before_head_commit
 test_aggregate_treats_llm_escalate_with_owner_override_as_owner_reviewed_pass
 test_owner_reviewed_workflow_shape
 


### PR DESCRIPTION
## 背景

关联 #109，主台账 #111。

#92 暴露出当前 owner-reviewed override 只能识别严格 `sentinel-owner-reviewed-override` 格式，不能吸收真实 GitHub SSOT 中的 Founder 治理裁决；#92 最终 Sentinel success 来自 LLM 改判 PASS，而不是 owner override 路径生效。

## 变更

- 保留原严格结构化路径：必须匹配 `head_sha`、deterministic PASS、`llm-review: ESCALATE`、follow-up URL。
- 新增 Founder governance ruling 路径：配置 actor 的评论若晚于 HEAD commit，且包含 deterministic PASS、`llm-review = ESCALATE`、governance owner verification、`runtime_authorization = false`、`engineering_start = forbidden`，则生成 owner-reviewed override evidence。
- 新增 `override_source` 字段，区分 `structured_head_sha` 与 `founder_governance_ruling`。
- 新增 stale Founder 裁决回归，防止旧裁决复用到新 HEAD。

## 验证

- `bash tests/test-owner-reviewed-override.sh`：passed。
- `bash tests/test-self-test-workflow.sh`：passed。
- `bash tests/test-llm-review-provider-router.sh`：passed。
- `bash -n scripts/owner-reviewed-override.sh tests/test-owner-reviewed-override.sh`：exit 0。

## 注意

此 PR 只补 Sentinel policy 识别能力。核心下游仓库仍需要单独配置 `owner_reviewed_override_actors` 或形成显式豁免，否则 override 路径仍会 disabled。
