### PR TITLE
fix(caller-sync): 暴露 token scope 诊断

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -132,6 +132,7 @@ jobs:
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_SKIP_LLM__/$(gha_expr "github.event_name == 'repository_dispatch' || fromJSON(github.event.inputs.skip_llm || 'false')")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_BASE_URL__/$(gha_expr "vars.HEIYUCODE_BASE_URL || 'https://www.heiyucode.com'")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_MODEL__/$(gha_expr "vars.HEIYUCODE_MODEL || ''")}"
+          CALLER_SYNC_TOKEN_REMEDIATION="CASCADE_TOKEN must have repo read/write access to every selected downstream repo and workflow write permission, because caller-sync updates .github/workflows/consistency-sentinel.yml."
 
           # Normalize canonical: strip comments, leading/trailing whitespace,
           # collapse whitespace for comparison
@@ -283,7 +284,8 @@ jobs:
 
                 # Update file on branch
                 ENCODED=$(echo "$CANONICAL_BODY" | base64 -w0)
-                UPDATE_RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+                UPDATE_RESPONSE="/tmp/update-response-${REPO}.json"
+                UPDATE_RESULT=$(curl -s -o "$UPDATE_RESPONSE" -w "%{http_code}" -X PUT \
                   -H "Authorization: token ${GH_TOKEN}" \
                   -H "Accept: application/vnd.github+json" \
                   "https://api.github.com/repos/huanlongAI/${REPO}/contents/.github/workflows/consistency-sentinel.yml" \
@@ -321,8 +323,20 @@ jobs:
                     echo "PR created: $PR_URL"
                   fi
                 else
-                  echo "File update failed (HTTP $UPDATE_RESULT) for ${REPO}"
-                  FAILED="${FAILED}${REPO}:update_http_${UPDATE_RESULT},"
+                  UPDATE_MESSAGE=$(jq -r '.message // empty' "$UPDATE_RESPONSE" 2>/dev/null || true)
+                  if [ "$UPDATE_RESULT" = "403" ] || [ "$UPDATE_RESULT" = "404" ]; then
+                    echo "::error title=Caller sync token lacks workflow write access::File update failed (HTTP $UPDATE_RESULT) for ${REPO}. ${CALLER_SYNC_TOKEN_REMEDIATION}"
+                    if [ -n "$UPDATE_MESSAGE" ]; then
+                      echo "GitHub API message: ${UPDATE_MESSAGE}"
+                    fi
+                    FAILED="${FAILED}${REPO}:update_http_${UPDATE_RESULT}_token_scope,"
+                  else
+                    echo "File update failed (HTTP $UPDATE_RESULT) for ${REPO}"
+                    if [ -n "$UPDATE_MESSAGE" ]; then
+                      echo "GitHub API message: ${UPDATE_MESSAGE}"
+                    fi
+                    FAILED="${FAILED}${REPO}:update_http_${UPDATE_RESULT},"
+                  fi
                 fi
               fi
             fi

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -69,4 +69,15 @@ do
     || fail "caller-sync workflow missing failure-handling marker: $expected"
 done
 
+for expected in \
+  'CALLER_SYNC_TOKEN_REMEDIATION=' \
+  'workflow write permission' \
+  'Caller sync token lacks workflow write access' \
+  'GitHub API message:' \
+  'token_scope'
+do
+  grep -Fq "$expected" "$CALLER_SYNC_WORKFLOW" \
+    || fail "caller-sync workflow missing token diagnostic marker: $expected"
+done
+
 echo "caller-sync dry_run input handling test passed"


### PR DESCRIPTION
## 变更内容

- 在 caller-sync workflow 中增加 token scope 诊断输出与失败标记。
- 补充 caller-sync workflow 测试断言，确保诊断字段和失败提示不会漂移。

## 原因

当 caller-sync 使用的 GitHub token 缺少 workflow 写权限时，当前失败信息不够明确，容易把权限问题误判为普通文件更新失败。该变更让 workflow 在失败路径中明确暴露非敏感诊断字段，便于治理总线定位 token 权限范围问题。

## 影响

- 不改变 reusable sentinel workflow 的权限声明方式。
- 不输出 secret/token 原文，仅输出权限诊断类别和 GitHub API message。
- 只影响 caller-sync 失败路径的可观测性和测试覆盖。

## 护栏

- 遵守 sentinel-shared 约束：可复用 workflow 不声明 permissions，caller repo 继续持有权限声明。
- 不引入 yq 依赖。
- 不触碰 main，保持 Draft PR 待检查通过后再进入合并判断。

## 验证命令

```bash
git diff --check origin/main..HEAD
bash tests/test-caller-sync-workflow.sh
```