### PR TITLE
docs(aux-llm): 对齐 provider router 投影

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ scripts/
   precheck-directory.sh      # D-4: 目录规范
   precheck-capability-source.sh  # D-5: 能力来源标注
   precheck-brand-token.sh    # D-6: Brand Token 硬编码检测
-  llm-review.sh              # LLM 一致性审查（Claude API）
+  llm-review.sh              # Required gate LLM provider router
+  llm-message-client.sh      # Auxiliary workflow LLM provider router
 prompts/
   system-prompt.md           # LLM 审查层 system prompt
 ```

--- a/tests/test-aux-llm-workflows.sh
+++ b/tests/test-aux-llm-workflows.sh
@@ -6,6 +6,7 @@ MATRIX_WORKFLOW="$ROOT_DIR/.github/workflows/matrix-updater.yml"
 AUTOFIX_WORKFLOW="$ROOT_DIR/.github/workflows/sentinel-autofix.yml"
 AUTO_FIX_SCRIPT="$ROOT_DIR/scripts/auto-fix.sh"
 CLIENT_SCRIPT="$ROOT_DIR/scripts/llm-message-client.sh"
+CLAUDE_DOC="$ROOT_DIR/CLAUDE.md"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -28,7 +29,7 @@ assert_file_not_contains() {
   fi
 }
 
-for file in "$MATRIX_WORKFLOW" "$AUTOFIX_WORKFLOW" "$AUTO_FIX_SCRIPT"; do
+for file in "$MATRIX_WORKFLOW" "$AUTOFIX_WORKFLOW" "$AUTO_FIX_SCRIPT" "$CLAUDE_DOC"; do
   [ -f "$file" ] || fail "Missing expected file: $file"
 done
 
@@ -61,6 +62,10 @@ assert_file_contains "$CLIENT_SCRIPT" "HEIYUCODE_API_KEY"
 assert_file_contains "$CLIENT_SCRIPT" "Authorization: Bearer"
 assert_file_contains "$CLIENT_SCRIPT" "x-api-key"
 assert_file_contains "$CLIENT_SCRIPT" "https://api.anthropic.com/v1/messages"
+
+assert_file_contains "$CLAUDE_DOC" "llm-message-client.sh"
+assert_file_contains "$CLAUDE_DOC" "LLM provider router"
+assert_file_not_contains "$CLAUDE_DOC" "LLM 一致性审查（Claude API）"
 
 ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file) }' \
   "$MATRIX_WORKFLOW" \


### PR DESCRIPTION
## 变更

- 更新 CLAUDE.md 文件结构说明，将 llm-review.sh 从旧 Claude API 口径改为 Required gate LLM provider router。
- 补充 llm-message-client.sh 为 Auxiliary workflow LLM provider router。
- 在 tests/test-aux-llm-workflows.sh 增加文档防漂移断言，避免旧 Claude API 投影回归。

## 价值

#115 已完成辅助 workflow provider router 接入；本 PR 收口文档投影，避免后续 agent 继续按 Anthropic-only / Claude API 旧口径理解 sentinel-shared。

## 风险与边界

- 文档与测试收口，不改运行逻辑。
- 不修改 reusable workflow permissions。

## 验证

- bash tests/test-aux-llm-workflows.sh && bash tests/test-agent-governance.sh && bash tests/test-self-test-workflow.sh
- find scripts tests .sentinel/checks -name '*.sh' -print | sort | xargs -n1 bash -n
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'
- git diff --check
- for test_file in tests/*.sh; do bash "$test_file"; done