### PR TITLE
docs: 收敛 AGENTS 治理地图

### DIFF
--- a/docs/agents-governance-map.md
+++ b/docs/agents-governance-map.md
@@ -1,25 +1,38 @@
 # HuanlongAI AGENTS Governance Map
 
-> Status: ACTIVE  
-> Last updated: 2026-06-03  
+> Status: ACTIVE
+> Last updated: 2026-06-04
 > Owner: NODE-M operational authority; AUM / tzhOS remain governance SSOT
 
-本文件是 `huanlongAI` 工作区的 Agent 入口地图，不是新的规则真源。规则真源仍是各 repo 的 `CLAUDE.md`、上级 `AGENTS.md`、tzhOS / AUM registry、仓库 CI gate 与当前任务契约。
+本文件是 `huanlongAI` 工作区的 Agent 入口治理地图，不是新的仓库清单真源，也不是新的规则真源。活跃仓库清单以 tzhOS `40-PPR/REPO-MAP.md@v1.4.12` 为 SSOT；规则真源仍是各 repo 的 `CLAUDE.md`、直接或目录继承的 `AGENTS.md`、tzhOS / AUM registry、仓库 CI gate 与当前任务契约。
 
 ## Principles
 
 - 每个正式 Git repo 根目录最多保留一个 Codex 入口 `AGENTS.md`。
 - `AGENTS.md` 应是薄入口，避免复制 `CLAUDE.md` 的长篇治理正文。
 - 只有子目录存在不同权限边界、接口 SSOT、安全规则或测试入口时，才允许新增 nested `AGENTS.md`。
+- 不在本文件维护 26 仓逐仓清单；逐仓活跃状态和本地路径由 tzhOS `REPO-MAP.md` 维护，入口覆盖由 tzhOS `40-PPR/check-deps.sh` 动态验证。
 - Desktop UI、`~/.codex/*`、`~/.claude/*`、memory、chat history 和本地 cache 都是 deploy target projection，不是治理 SSOT。
 - 入口漂移由 Sentinel `D-10 Agent Governance` 检查兜底。
 
-## Repo Map
+## Coverage Model
 
-| Repo | Codex entry | Claude entry | Rule owner | Nested AGENTS | Verification |
-|------|-------------|--------------|------------|---------------|--------------|
-| `super-founder` | `AGENTS.md` thin entry | `CLAUDE.md` long-form project rules | `CLAUDE.md` + tzhOS R-0122 / AUM | Disabled by default | `bash ../sentinel-shared/scripts/precheck-agent-governance.sh` from repo root |
-| `sentinel-shared` | `AGENTS.md` thin entry | `CLAUDE.md` hub rules | `CLAUDE.md` + this map | Disabled by default | `bash tests/test-agent-governance.sh` |
+| Layer | Owner | Purpose | Verification |
+|-------|-------|---------|--------------|
+| Active repo inventory | tzhOS `40-PPR/REPO-MAP.md@v1.4.12` | 26 active repos, paths, visibility, Write-Owner, repo-level constraints | `bash 40-PPR/check-deps.sh` in tzhOS |
+| Entry coverage | tzhOS `40-PPR/check-deps.sh` | Dynamic check that every active repo has a direct or inherited `AGENTS.md` / `CLAUDE.md` entry | tzhOS governance-check / local `check-deps.sh` |
+| Projection drift | sentinel-shared D-10 | Repo-local scan for stale owner/runtime projection and oversized duplicated `AGENTS.md` files | `bash scripts/precheck-agent-governance.sh` from target repo root |
+| Map invariants | sentinel-shared tests | Prevent this map from becoming a second stale repo inventory | `bash tests/test-agent-governance.sh` |
+
+## Exception Map
+
+This table records only exceptions and important entry topology. It is not a full repo inventory.
+
+| Scope | Codex entry | Claude entry | Rule owner | Notes |
+|-------|-------------|--------------|------------|-------|
+| `super-founder` | root `AGENTS.md` thin entry | root `CLAUDE.md` long-form project rules | `CLAUDE.md` + tzhOS R-0122 / AUM | Root `AGENTS.md` must stay thin; D-10 blocks stale NODE-A and long duplicated governance sections. |
+| `sentinel-shared` | root `AGENTS.md` thin entry | root `CLAUDE.md` hub rules | `CLAUDE.md` + this map | Changes to Agent governance scripts/docs require `bash tests/test-agent-governance.sh`. |
+| `hl-app-certificates` | inherited `huanlong/AGENTS.md` | none at repo root | tzhOS `REPO-MAP.md@v1.4.12` + repo README/security boundary | Signing asset repository; Sentinel caller is deterministic-only / `skip_llm: true`; `.p8` material must stay in Secret Store. |
 
 ## Drift Rules
 
@@ -27,6 +40,7 @@ Sentinel D-10 blocks:
 
 - root `CLAUDE.md` without root `AGENTS.md`;
 - stale `Write-Owner: NODE-A` / `NODE-M + NODE-A` projections;
+- stale narrow `NODE-M` read-only projections for Huanlong active repos;
 - stale `GHThemeManager.current` theme guidance;
 - long `AGENTS.md` files over 32 KiB;
 - `AGENTS.md` duplicating long-form sections that should live in `CLAUDE.md`.

--- a/tests/test-agent-governance.sh
+++ b/tests/test-agent-governance.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/precheck-agent-governance.sh"
+MAP_DOC="$ROOT_DIR/docs/agents-governance-map.md"
 
 PASS_COUNT=0
 
@@ -42,6 +43,13 @@ run_check() {
 
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
+
+MAP_DOC_CONTENT="$(cat "$MAP_DOC")"
+assert_contains "$MAP_DOC_CONTENT" "REPO-MAP.md@v1.4.12"
+assert_contains "$MAP_DOC_CONTENT" "不在本文件维护 26 仓逐仓清单"
+assert_contains "$MAP_DOC_CONTENT" "40-PPR/check-deps.sh"
+assert_contains "$MAP_DOC_CONTENT" "hl-app-certificates"
+pass "keeps AGENTS governance map anchored to REPO-MAP SSOT"
 
 # Missing Codex entrypoint is blocked when CLAUDE.md exists.
 MISSING_AGENTS="$TMP_ROOT/missing-agents"


### PR DESCRIPTION
## Summary

本 PR 收敛 `sentinel-shared` 的 AGENTS governance map，避免它继续维护第二份不完整的逐仓 repo map。

## Changes

- 将 `docs/agents-governance-map.md` 明确锚定到 tzhOS `40-PPR/REPO-MAP.md@v1.4.12`，由 REPO-MAP 维护 26 个 active repo 的清单、路径、Owner 与约束。
- 将原来的两行逐仓表改为 coverage model：
  - active repo inventory：tzhOS `REPO-MAP.md`
  - entry coverage：tzhOS `40-PPR/check-deps.sh`
  - projection drift：sentinel-shared D-10
  - map invariants：sentinel-shared tests
- 只保留 exception map，记录 `super-founder`、`sentinel-shared` 和 `hl-app-certificates` 这类入口拓扑/安全边界例外。
- 为 `tests/test-agent-governance.sh` 增加地图不变量测试，要求 map 保持锚定 REPO-MAP SSOT、`check-deps.sh` 和 `hl-app-certificates` 例外。

## Why

前序治理已将 `hl-app-certificates` 登记进 tzhOS REPO-MAP，并把 tzhOS `check-deps.sh` 改为动态检查 26 个 active repo 的 `AGENTS.md / CLAUDE.md` 入口覆盖。sentinel-shared 侧如果继续维护逐仓表，会再次成为漂移源。

## Verification

- `bash tests/test-agent-governance.sh`
- `bash -n scripts/*.sh tests/*.sh`
- `git diff --check`
- `for t in tests/*.sh; do bash "$t"; done`
