### PR TITLE
fix(agent-governance): ignore build dependency cache

### DIFF
--- a/scripts/precheck-agent-governance.sh
+++ b/scripts/precheck-agent-governance.sh
@@ -26,6 +26,7 @@ add_issue() {
 instruction_files() {
   find . \
     \( -path './.git' -o -path './.git/*' \
+       -o -path './.build' -o -path './.build/*' \
        -o -path './.sentinel/results' -o -path './.sentinel/results/*' \
        -o -path './.sentinel-shared' -o -path './.sentinel-shared/*' \) -prune \
     -o \( -name 'AGENTS.md' -o -name 'CLAUDE.md' \) -type f -print \

--- a/tests/test-agent-governance.sh
+++ b/tests/test-agent-governance.sh
@@ -113,6 +113,36 @@ assert_contains "$LONG_OUTPUT" "AGENTS.md exceeds 32768 bytes"
 assert_contains "$LONG_OUTPUT" "duplicates long-form governance sections"
 pass "blocks long duplicate AGENTS.md"
 
+# Build dependency caches are not repo instruction entrypoints.
+BUILD_CACHE_REPO="$TMP_ROOT/build-cache"
+make_repo "$BUILD_CACHE_REPO"
+cat > "$BUILD_CACHE_REPO/AGENTS.md" <<'EOF'
+# Repo AGENTS
+
+本文件是 Codex 入口。完整项目规则见 `CLAUDE.md`。
+EOF
+cat > "$BUILD_CACHE_REPO/CLAUDE.md" <<'EOF'
+# Repo CLAUDE
+
+> **Write-Owner: NODE-M**
+EOF
+mkdir -p "$BUILD_CACHE_REPO/.build/checkouts/guanghe"
+cat > "$BUILD_CACHE_REPO/.build/checkouts/guanghe/CLAUDE.md" <<'EOF'
+# Cached dependency CLAUDE
+
+颜色通过 GHThemeManager.current.xxx 引用。
+EOF
+set +e
+BUILD_CACHE_OUTPUT=$(run_check "$BUILD_CACHE_REPO")
+BUILD_CACHE_CODE=$?
+set -e
+if [ "$BUILD_CACHE_CODE" -ne 0 ]; then
+  echo "$BUILD_CACHE_OUTPUT"
+  fail "expected build dependency cache instruction files to be ignored"
+fi
+assert_contains "$BUILD_CACHE_OUTPUT" "D-10 PASS"
+pass "ignores build dependency cache instruction files"
+
 # Thin AGENTS.md plus CLAUDE.md passes.
 PASS_REPO="$TMP_ROOT/pass"
 make_repo "$PASS_REPO"


### PR DESCRIPTION
## 变更

- D-10 `precheck-agent-governance.sh` 排除 `.build/**`。
- 增加回归测试，覆盖 SwiftPM dependency cache 中存在 `CLAUDE.md` 的场景。

## 原因

`super-founder` 本地运行 D-10 时，`.build/checkouts/guanghe/CLAUDE.md` 被误判为当前仓库 agent 入口，导致旧投影假阳性。`.build/checkouts/**` 是构建依赖缓存，不是 repo instruction entrypoint。

## 验证

- `bash tests/test-agent-governance.sh`
- `bash -n scripts/*.sh tests/*.sh`
- `git diff --check origin/main...HEAD`
- `for t in tests/*.sh; do bash "$t"; done`
