### PR TITLE
fix(agent-governance): ignore Claude runtime worktrees

### DIFF
--- a/scripts/precheck-agent-governance.sh
+++ b/scripts/precheck-agent-governance.sh
@@ -27,6 +27,7 @@ instruction_files() {
   find . \
     \( -path './.git' -o -path './.git/*' \
        -o -path './.build' -o -path './.build/*' \
+       -o -path './.claude/worktrees' -o -path './.claude/worktrees/*' \
        -o -path './.sentinel/results' -o -path './.sentinel/results/*' \
        -o -path './.sentinel-shared' -o -path './.sentinel-shared/*' \) -prune \
     -o \( -name 'AGENTS.md' -o -name 'CLAUDE.md' \) -type f -print \

--- a/tests/test-agent-governance.sh
+++ b/tests/test-agent-governance.sh
@@ -143,6 +143,36 @@ fi
 assert_contains "$BUILD_CACHE_OUTPUT" "D-10 PASS"
 pass "ignores build dependency cache instruction files"
 
+# Claude runtime worktrees are not repo instruction entrypoints.
+CLAUDE_WORKTREE_REPO="$TMP_ROOT/claude-worktree"
+make_repo "$CLAUDE_WORKTREE_REPO"
+cat > "$CLAUDE_WORKTREE_REPO/AGENTS.md" <<'EOF'
+# Repo AGENTS
+
+本文件是 Codex 入口。完整项目规则见 `CLAUDE.md`。
+EOF
+cat > "$CLAUDE_WORKTREE_REPO/CLAUDE.md" <<'EOF'
+# Repo CLAUDE
+
+> **Write-Owner: NODE-M**
+EOF
+mkdir -p "$CLAUDE_WORKTREE_REPO/.claude/worktrees/musing-vaughan-9b904b"
+cat > "$CLAUDE_WORKTREE_REPO/.claude/worktrees/musing-vaughan-9b904b/CLAUDE.md" <<'EOF'
+# Runtime worktree CLAUDE
+
+颜色通过 GHThemeManager.current.xxx 引用。
+EOF
+set +e
+CLAUDE_WORKTREE_OUTPUT=$(run_check "$CLAUDE_WORKTREE_REPO")
+CLAUDE_WORKTREE_CODE=$?
+set -e
+if [ "$CLAUDE_WORKTREE_CODE" -ne 0 ]; then
+  echo "$CLAUDE_WORKTREE_OUTPUT"
+  fail "expected Claude runtime worktree instruction files to be ignored"
+fi
+assert_contains "$CLAUDE_WORKTREE_OUTPUT" "D-10 PASS"
+pass "ignores Claude runtime worktree instruction files"
+
 # Thin AGENTS.md plus CLAUDE.md passes.
 PASS_REPO="$TMP_ROOT/pass"
 make_repo "$PASS_REPO"


### PR DESCRIPTION
## 变更

- D-10 agent governance 扫描排除 `.claude/worktrees/**`。
- 增加回归测试，覆盖 Claude runtime worktree 中存在 `CLAUDE.md` 的场景。

## 原因

`.claude/worktrees/**` 是本地 runtime worktree 缓存，不是仓库级 Agent instruction entrypoint。当前 REPO-MAP active repos 严格 D-10 扫描会把 `guanghe/.claude/worktrees/**/CLAUDE.md` 误判为治理漂移。

## 验证

- `bash tests/test-agent-governance.sh`
- `bash -n scripts/*.sh tests/*.sh`
- `git diff --check origin/main...HEAD`
- `for t in tests/*.sh; do bash "$t"; done`
- REPO-MAP active repos 逐仓 D-10 扫描全部 PASS（本地临时 RESULTS_DIR）
