### PR TITLE
fix(review-gate): handle large audit payloads

### DIFF
--- a/scripts/review-gate-audit.sh
+++ b/scripts/review-gate-audit.sh
@@ -45,7 +45,7 @@ write_collection_error() {
 }
 
 collect_live_prs() {
-  local token tmp repos_json repo prs_json enriched_prs pr_number pr_json comments_json
+  local token tmp repositories_file next_file repo prs_file enriched_file pr_file comments_file pr_number pr_json
   token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
   gh_with_auth() {
@@ -57,48 +57,68 @@ collect_live_prs() {
   }
 
   tmp="$(mktemp -d)"
-  repos_json="[]"
+  repositories_file="$tmp/repositories.json"
+  printf '[]\n' > "$repositories_file"
 
   for repo in $REPOS; do
-    if ! prs_json=$(gh_with_auth pr list \
+    prs_file="$tmp/${repo}-prs.json"
+    enriched_file="$tmp/${repo}-enriched.json"
+    printf '[]\n' > "$enriched_file"
+
+    if ! gh_with_auth pr list \
       --repo "${ORG}/${repo}" \
       --state merged \
       --limit "$LIMIT" \
-      --json number,title,url,mergedAt,reviewDecision,reviews,headRefOid 2>"$tmp/pr-list.err"); then
-      repos_json="$(jq -c \
+      --json number,title,url,mergedAt,reviewDecision,reviews,headRefOid >"$prs_file" 2>"$tmp/pr-list.err"; then
+      next_file="$tmp/repositories-next.json"
+      jq -c \
         --arg name "$repo" \
-        --arg error "$(cat "$tmp/pr-list.err")" \
-        '. + [{name: $name, pull_requests: [], collection_error: $error}]' <<< "$repos_json")"
+        --rawfile error "$tmp/pr-list.err" \
+        '. + [{name: $name, pull_requests: [], collection_error: $error}]' \
+        "$repositories_file" > "$next_file"
+      mv "$next_file" "$repositories_file"
       continue
     fi
 
-    enriched_prs="[]"
     while IFS= read -r pr_json; do
       [ -z "$pr_json" ] && continue
       pr_number="$(jq -r '.number' <<< "$pr_json")"
-      if comments_json=$(gh_with_auth pr view "$pr_number" \
+      pr_file="$tmp/${repo}-${pr_number}-pr.json"
+      comments_file="$tmp/${repo}-${pr_number}-comments.json"
+      printf '%s\n' "$pr_json" > "$pr_file"
+
+      if gh_with_auth pr view "$pr_number" \
         --repo "${ORG}/${repo}" \
         --json comments \
-        --jq '.comments' 2>"$tmp/pr-view.err"); then
-        enriched_prs="$(jq -c \
-          --argjson pr "$pr_json" \
-          --argjson comments "$comments_json" \
-          '. + [($pr + {comments: $comments})]' <<< "$enriched_prs")"
+        --jq '.comments' >"$comments_file" 2>"$tmp/pr-view.err"; then
+        next_file="$tmp/${repo}-enriched-next.json"
+        jq -c \
+          --slurpfile pr "$pr_file" \
+          --slurpfile comments "$comments_file" \
+          '. + [($pr[0] + {comments: $comments[0]})]' \
+          "$enriched_file" > "$next_file"
+        mv "$next_file" "$enriched_file"
       else
-        enriched_prs="$(jq -c \
-          --argjson pr "$pr_json" \
-          --arg error "$(cat "$tmp/pr-view.err")" \
-          '. + [($pr + {comments: [], comment_collection_error: $error})]' <<< "$enriched_prs")"
+        next_file="$tmp/${repo}-enriched-next.json"
+        jq -c \
+          --slurpfile pr "$pr_file" \
+          --rawfile error "$tmp/pr-view.err" \
+          '. + [($pr[0] + {comments: [], comment_collection_error: $error})]' \
+          "$enriched_file" > "$next_file"
+        mv "$next_file" "$enriched_file"
       fi
-    done < <(jq -c '.[]' <<< "$prs_json")
+    done < <(jq -c '.[]' "$prs_file")
 
-    repos_json="$(jq -c \
+    next_file="$tmp/repositories-next.json"
+    jq -c \
       --arg name "$repo" \
-      --argjson pull_requests "$enriched_prs" \
-      '. + [{name: $name, pull_requests: $pull_requests}]' <<< "$repos_json")"
+      --slurpfile pull_requests "$enriched_file" \
+      '. + [{name: $name, pull_requests: $pull_requests[0]}]' \
+      "$repositories_file" > "$next_file"
+    mv "$next_file" "$repositories_file"
   done
 
-  jq -n --argjson repositories "$repos_json" '{repositories: $repositories}'
+  jq -n --slurpfile repositories "$repositories_file" '{repositories: $repositories[0]}'
 }
 
 if [ -n "$FIXTURE" ]; then

--- a/tests/test-review-gate-audit.sh
+++ b/tests/test-review-gate-audit.sh
@@ -213,9 +213,66 @@ SH
     fail "live gh collection did not audit fake merged PR"
 }
 
+test_live_collection_handles_large_comment_payload_without_arg_limit() {
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+[
+  {
+    "number": 200,
+    "url": "https://github.com/huanlongAI/hl-dispatch/pull/200",
+    "title": "fix: approved change with large discussion",
+    "mergedAt": "2026-06-04T04:00:00Z",
+    "reviewDecision": "APPROVED",
+    "headRefOid": "4444444444444444444444444444444444444444",
+    "reviews": [
+      {"state": "APPROVED", "author": {"login": "gate-reviewer"}}
+    ]
+  }
+]
+JSON
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '[{"body":"'
+  head -c 3000000 /dev/zero | tr '\0' 'x'
+  printf '","author":{"login":"gate-owner"},"url":"https://github.com/huanlongAI/hl-dispatch/pull/200#issuecomment-large"}]\n'
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+SH
+  chmod +x "$tmp/bin/gh"
+
+  PATH="$tmp/bin:$PATH" \
+    GH_TOKEN="" \
+    GITHUB_TOKEN="" \
+    REVIEW_GATE_AUDIT_REPOS="hl-dispatch" \
+    REVIEW_GATE_AUDIT_LIMIT="1" \
+    REVIEW_GATE_AUDIT_OUTPUT="$tmp/result.json" \
+    bash "$SCRIPT" >/dev/null
+
+  jq -e '
+    .passed == true
+    and .checked == 1
+    and (.collection_errors | length) == 0
+    and (.violations | length) == 0
+  ' "$tmp/result.json" >/dev/null ||
+    fail "large PR comment payload should not fail live collection"
+}
+
 test_reviewless_merge_fails_audit
 test_approved_review_passes_audit
 test_structured_owner_override_accounts_for_reviewless_merge
 test_live_collection_uses_gh_cli_auth_without_token_env
+test_live_collection_handles_large_comment_payload_without_arg_limit
 
 echo "review-gate audit tests passed"


### PR DESCRIPTION
## 变更

- 修复 `scripts/review-gate-audit.sh` 在大 comments payload 下使用 `jq --argjson` 传递 JSON 导致 `Argument list too long` 的问题。
- live collection 改为将 PR / comments / repo aggregate JSON 写入临时文件，并用 `--slurpfile` / `--rawfile` 传递给 `jq`。
- 新增 3MB PR comment payload 回归测试，防止回退到命令参数传大 JSON。

## 背景

默认核心 7 仓 `Review Gate Audit` production run `26938050145` 失败于：

```text
scripts/review-gate-audit.sh: line 86: jq: Argument list too long
```

这不是 GitHub 权限或 review gate 数据问题，而是脚本在大规模 PR/comment 采集时的扩展性缺陷。

## 验证

- RED：大 payload 测试在旧实现下复现 `Argument list too long`。
- GREEN：`bash tests/test-review-gate-audit.sh`
- `bash tests/test-self-test-workflow.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- Ruby YAML parse for `.github/workflows/*.yml`
- `git diff --check`
- 本地默认 7 仓 live audit 已能完成采集：`checked=144`、`violations=139`、`collection_errors=0`，按预期 fail closed。

## 跟踪

- `#109`
- `#111`
