### PR TITLE
docs(agent-governance): document runtime scan exclusions

### DIFF
--- a/docs/agents-governance-map.md
+++ b/docs/agents-governance-map.md
@@ -44,3 +44,8 @@ Sentinel D-10 blocks:
 - stale `GHThemeManager.current` theme guidance;
 - long `AGENTS.md` files over 32 KiB;
 - `AGENTS.md` duplicating long-form sections that should live in `CLAUDE.md`.
+
+D-10 intentionally ignores runtime/dependency surfaces that are not repo instruction entrypoints:
+
+- `.build/checkouts/**` SwiftPM dependency caches;
+- `.claude/worktrees/**` Claude runtime worktree projections.

--- a/tests/test-agent-governance.sh
+++ b/tests/test-agent-governance.sh
@@ -49,6 +49,8 @@ assert_contains "$MAP_DOC_CONTENT" "REPO-MAP.md@v1.4.12"
 assert_contains "$MAP_DOC_CONTENT" "不在本文件维护 26 仓逐仓清单"
 assert_contains "$MAP_DOC_CONTENT" "40-PPR/check-deps.sh"
 assert_contains "$MAP_DOC_CONTENT" "hl-app-certificates"
+assert_contains "$MAP_DOC_CONTENT" ".build/checkouts"
+assert_contains "$MAP_DOC_CONTENT" ".claude/worktrees"
 pass "keeps AGENTS governance map anchored to REPO-MAP SSOT"
 
 # Missing Codex entrypoint is blocked when CLAUDE.md exists.


### PR DESCRIPTION
## 变更

- 在 AGENTS governance map 中显式记录 D-10 忽略的 runtime/dependency surfaces：
  - `.build/checkouts/**`
  - `.claude/worktrees/**`
- 增加 map invariant 测试，防止文档漏写这两个扫描边界。

## 原因

D-10 已通过 #119 / #120 排除构建依赖缓存和 Claude runtime worktree；地图文档也需要记录同一治理边界，避免脚本行为和治理地图再次漂移。

## 验证

- `bash tests/test-agent-governance.sh`
- `bash -n scripts/*.sh tests/*.sh`
- `git diff --check origin/main...HEAD`
- `for t in tests/*.sh; do bash "$t"; done`
