### PR TITLE
fix(review-gate): 给历史审计违规加生效基线

### DIFF
--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "30"
         type: string
+      effective_after:
+        description: ISO-8601 merge time after which reviewless merges fail the audit
+        required: false
+        default: "2026-06-04T06:36:06Z"
+        type: string
   schedule:
     - cron: '20 1 * * *'
 
@@ -34,4 +39,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           REVIEW_GATE_AUDIT_REPOS: ${{ inputs.repos || 'hl-platform hl-framework hl-factory hl-dispatch hl-contracts hl-console-native team-memory' }}
           REVIEW_GATE_AUDIT_LIMIT: ${{ inputs.limit || '30' }}
+          REVIEW_GATE_AUDIT_EFFECTIVE_AFTER: ${{ inputs.effective_after || '2026-06-04T06:36:06Z' }}
         run: bash scripts/review-gate-audit.sh

--- a/scripts/review-gate-audit.sh
+++ b/scripts/review-gate-audit.sh
@@ -14,6 +14,7 @@ LIMIT="${REVIEW_GATE_AUDIT_LIMIT:-30}"
 OUTPUT="${REVIEW_GATE_AUDIT_OUTPUT:-.sentinel/results/review-gate-audit.json}"
 FIXTURE="${REVIEW_GATE_AUDIT_FIXTURE:-}"
 OVERRIDE_ACTORS="${REVIEW_GATE_AUDIT_OVERRIDE_ACTORS:-}"
+EFFECTIVE_AFTER="${REVIEW_GATE_AUDIT_EFFECTIVE_AFTER:-}"
 
 mkdir -p "$(dirname "$OUTPUT")"
 
@@ -32,13 +33,16 @@ write_collection_error() {
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg organization "$ORG" \
     --arg reason "$reason" \
+    --arg effective_after "$EFFECTIVE_AFTER" \
     '{
       audit_id: $audit_id,
       generated_at: $generated_at,
       organization: $organization,
+      effective_after: (if $effective_after == "" then null else $effective_after end),
       passed: false,
       checked: 0,
       violations: [],
+      accounted_legacy_violations: [],
       accounted_overrides: [],
       collection_errors: [{reason: $reason}]
     }' > "$OUTPUT"
@@ -134,6 +138,7 @@ result_json="$(
     --arg audit_id "review-gate-audit" \
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg organization "$ORG" \
+    --arg effective_after "$EFFECTIVE_AFTER" \
     --argjson actors "$actors_json" \
     '
       def login_of($comment):
@@ -159,20 +164,27 @@ result_json="$(
           | select(.body | test("reason:[[:space:]]*.+"; "i"))
         ][0] // null);
 
+      def merged_at($pr):
+        ($pr.mergedAt // $pr.merged_at // "");
+
+      def is_pre_effective($pr):
+        ($effective_after != "" and (merged_at($pr) < $effective_after));
+
       [
         (.repositories // [])[]
         | (.name // .repo // "") as $repo
         | (.pull_requests // [])[]
-        | select((.mergedAt // .merged_at // "") != "")
+        | select(merged_at(.) != "")
         | select((.reviewDecision // .review_decision // "") == "REVIEW_REQUIRED")
         | select(approved_review_count(.) == 0)
         | override_comment(.) as $override
         | select($override == null)
+        | select(is_pre_effective(.) | not)
         | {
             repo: $repo,
             number: .number,
             url: .url,
-            mergedAt: (.mergedAt // .merged_at // ""),
+            mergedAt: merged_at(.),
             reviewDecision: (.reviewDecision // .review_decision // ""),
             approved_reviews: approved_review_count(.),
             reason: "merged_review_required_without_approval_or_override"
@@ -182,7 +194,28 @@ result_json="$(
         (.repositories // [])[]
         | (.name // .repo // "") as $repo
         | (.pull_requests // [])[]
-        | select((.mergedAt // .merged_at // "") != "")
+        | select(merged_at(.) != "")
+        | select((.reviewDecision // .review_decision // "") == "REVIEW_REQUIRED")
+        | select(approved_review_count(.) == 0)
+        | override_comment(.) as $override
+        | select($override == null)
+        | select(is_pre_effective(.))
+        | {
+            repo: $repo,
+            number: .number,
+            url: .url,
+            mergedAt: merged_at(.),
+            reviewDecision: (.reviewDecision // .review_decision // ""),
+            approved_reviews: approved_review_count(.),
+            source: "pre_effective_review_gate_audit_baseline",
+            effective_after: $effective_after
+          }
+      ] as $accounted_legacy_violations
+      | [
+        (.repositories // [])[]
+        | (.name // .repo // "") as $repo
+        | (.pull_requests // [])[]
+        | select(merged_at(.) != "")
         | select((.reviewDecision // .review_decision // "") == "REVIEW_REQUIRED")
         | select(approved_review_count(.) == 0)
         | override_comment(.) as $override
@@ -199,7 +232,7 @@ result_json="$(
       | [
         (.repositories // [])[]
         | (.pull_requests // [])[]
-        | select((.mergedAt // .merged_at // "") != "")
+        | select(merged_at(.) != "")
       ] as $checked_prs
       | [
         (.repositories // [])[]
@@ -210,10 +243,12 @@ result_json="$(
           audit_id: $audit_id,
           generated_at: $generated_at,
           organization: $organization,
+          effective_after: (if $effective_after == "" then null else $effective_after end),
           repositories: [(.repositories // [])[] | (.name // .repo // "")],
           passed: (($violations | length) == 0 and ($collection_errors | length) == 0),
           checked: ($checked_prs | length),
           violations: $violations,
+          accounted_legacy_violations: $accounted_legacy_violations,
           accounted_overrides: $accounted_overrides,
           collection_errors: $collection_errors
         }
@@ -226,7 +261,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
     echo "## Review Gate Audit"
     echo ""
-    jq -r '"Checked: \(.checked) | Violations: \(.violations | length) | Accounted overrides: \(.accounted_overrides | length)"' "$OUTPUT"
+    jq -r '"Checked: \(.checked) | Violations: \(.violations | length) | Legacy accounted: \(.accounted_legacy_violations | length) | Accounted overrides: \(.accounted_overrides | length)"' "$OUTPUT"
     echo ""
     if jq -e '(.violations | length) > 0' "$OUTPUT" >/dev/null; then
       echo "| Repo | PR | Reason |"

--- a/tests/test-review-gate-audit.sh
+++ b/tests/test-review-gate-audit.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/review-gate-audit.sh"
+WORKFLOW="$ROOT_DIR/.github/workflows/review-gate-audit.yml"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -24,6 +25,31 @@ write_reviewless_fixture() {
           "mergedAt": "2026-06-04T01:46:46Z",
           "reviewDecision": "REVIEW_REQUIRED",
           "headRefOid": "1111111111111111111111111111111111111111",
+          "reviews": [],
+          "comments": []
+        }
+      ]
+    }
+  ]
+}
+JSON
+}
+
+write_post_effective_reviewless_fixture() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "repositories": [
+    {
+      "name": "hl-dispatch",
+      "pull_requests": [
+        {
+          "number": 194,
+          "url": "https://github.com/huanlongAI/hl-dispatch/pull/194",
+          "title": "fix: new reviewless governance change",
+          "mergedAt": "2026-06-04T07:00:00Z",
+          "reviewDecision": "REVIEW_REQUIRED",
+          "headRefOid": "5555555555555555555555555555555555555555",
           "reviews": [],
           "comments": []
         }
@@ -155,6 +181,58 @@ test_structured_owner_override_accounts_for_reviewless_merge() {
     fail "structured owner override should account for reviewless merge"
 }
 
+test_pre_effective_reviewless_merge_is_accounted_as_legacy() {
+  local tmp code
+  tmp="$(mktemp -d)"
+  write_reviewless_fixture "$tmp/fixture.json"
+
+  set +e
+  REVIEW_GATE_AUDIT_FIXTURE="$tmp/fixture.json" \
+    REVIEW_GATE_AUDIT_OUTPUT="$tmp/result.json" \
+    REVIEW_GATE_AUDIT_EFFECTIVE_AFTER="2026-06-04T06:36:06Z" \
+    bash "$SCRIPT" >"$tmp/stdout" 2>"$tmp/stderr"
+  code=$?
+  set -e
+
+  [ "$code" -eq 0 ] || fail "pre-effective reviewless merged PR should pass as accounted legacy, got exit $code"
+
+  jq -e '
+    .passed == true
+    and .effective_after == "2026-06-04T06:36:06Z"
+    and (.violations | length) == 0
+    and (.accounted_legacy_violations | length) == 1
+    and .accounted_legacy_violations[0].repo == "hl-dispatch"
+    and .accounted_legacy_violations[0].number == 191
+    and .accounted_legacy_violations[0].source == "pre_effective_review_gate_audit_baseline"
+  ' "$tmp/result.json" >/dev/null ||
+    fail "pre-effective reviewless merge should be accounted as legacy, not fail audit"
+}
+
+test_post_effective_reviewless_merge_still_fails_audit() {
+  local tmp code
+  tmp="$(mktemp -d)"
+  write_post_effective_reviewless_fixture "$tmp/fixture.json"
+
+  set +e
+  REVIEW_GATE_AUDIT_FIXTURE="$tmp/fixture.json" \
+    REVIEW_GATE_AUDIT_OUTPUT="$tmp/result.json" \
+    REVIEW_GATE_AUDIT_EFFECTIVE_AFTER="2026-06-04T06:36:06Z" \
+    bash "$SCRIPT" >"$tmp/stdout" 2>"$tmp/stderr"
+  code=$?
+  set -e
+
+  [ "$code" -ne 0 ] || fail "post-effective reviewless merged PR must fail audit"
+  jq -e '
+    .passed == false
+    and .effective_after == "2026-06-04T06:36:06Z"
+    and (.violations | length) == 1
+    and (.accounted_legacy_violations | length) == 0
+    and .violations[0].repo == "hl-dispatch"
+    and .violations[0].number == 194
+  ' "$tmp/result.json" >/dev/null ||
+    fail "post-effective reviewless merge violation was not recorded"
+}
+
 test_live_collection_uses_gh_cli_auth_without_token_env() {
   local tmp code
   tmp="$(mktemp -d)"
@@ -269,10 +347,22 @@ SH
     fail "large PR comment payload should not fail live collection"
 }
 
+test_workflow_configures_effective_after_baseline() {
+  grep -q 'effective_after:' "$WORKFLOW" ||
+    fail "review gate audit workflow must expose effective_after input"
+  grep -q 'REVIEW_GATE_AUDIT_EFFECTIVE_AFTER:' "$WORKFLOW" ||
+    fail "review gate audit workflow must pass REVIEW_GATE_AUDIT_EFFECTIVE_AFTER"
+  grep -q '2026-06-04T06:36:06Z' "$WORKFLOW" ||
+    fail "review gate audit workflow must default to #117 merge activation time"
+}
+
 test_reviewless_merge_fails_audit
 test_approved_review_passes_audit
 test_structured_owner_override_accounts_for_reviewless_merge
+test_pre_effective_reviewless_merge_is_accounted_as_legacy
+test_post_effective_reviewless_merge_still_fails_audit
 test_live_collection_uses_gh_cli_auth_without_token_env
 test_live_collection_handles_large_comment_payload_without_arg_limit
+test_workflow_configures_effective_after_baseline
 
 echo "review-gate audit tests passed"


### PR DESCRIPTION
## 变更

- 为 `Review Gate Audit` 增加 `REVIEW_GATE_AUDIT_EFFECTIVE_AFTER`。
- baseline 前的 reviewless merged PR 记入 `accounted_legacy_violations`，不再让 scheduled/main audit 因历史债务失败。
- baseline 后的新 reviewless merge 仍保持 fail-closed。
- workflow 暴露 `effective_after` 输入，默认值为 `2026-06-04T06:36:06Z`，即 `#117` 合并启用时间。

## 背景

`#117` 引入 audit 后，历史 merged PR 中存在大量 `reviewDecision=REVIEW_REQUIRED` 且无 approved review / structured override 的记录。它们应被持续记账，但不应让新启用的 scheduled/main monitoring 永久失败；真正需要阻断的是 baseline 之后的新违规。

## 验证

- `bash tests/test-review-gate-audit.sh`
- `bash tests/test-self-test-workflow.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- Ruby YAML parse for `.github/workflows/*.yml`
- `git diff --check`
- `for t in tests/*.sh; do bash "$t"; done`
- live audit with `REVIEW_GATE_AUDIT_EFFECTIVE_AFTER=2026-06-04T06:36:06Z`: `checked=144`, `violations=0`, `accounted_legacy_violations=139`, `collection_errors=0`
