### PR TITLE
[codex] fix review gate operational lookback window

### DIFF
--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -13,6 +13,16 @@ on:
         required: false
         default: "30"
         type: string
+      lookback_days:
+        description: Days of merged PR history to audit; use all for full audit
+        required: false
+        default: "7"
+        type: string
+      merged_since:
+        description: Explicit UTC lower bound, overrides lookback_days when set
+        required: false
+        default: ""
+        type: string
   schedule:
     - cron: '20 1 * * *'
 
@@ -34,4 +44,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           REVIEW_GATE_AUDIT_REPOS: ${{ inputs.repos || 'hl-platform hl-framework hl-factory hl-dispatch hl-contracts hl-console-native team-memory' }}
           REVIEW_GATE_AUDIT_LIMIT: ${{ inputs.limit || '30' }}
+          REVIEW_GATE_AUDIT_LOOKBACK_DAYS: ${{ inputs.lookback_days || '7' }}
+          REVIEW_GATE_AUDIT_MERGED_SINCE: ${{ inputs.merged_since || '' }}
         run: bash scripts/review-gate-audit.sh

--- a/scripts/review-gate-audit.sh
+++ b/scripts/review-gate-audit.sh
@@ -14,8 +14,41 @@ LIMIT="${REVIEW_GATE_AUDIT_LIMIT:-30}"
 OUTPUT="${REVIEW_GATE_AUDIT_OUTPUT:-.sentinel/results/review-gate-audit.json}"
 FIXTURE="${REVIEW_GATE_AUDIT_FIXTURE:-}"
 OVERRIDE_ACTORS="${REVIEW_GATE_AUDIT_OVERRIDE_ACTORS:-}"
+LOOKBACK_DAYS="${REVIEW_GATE_AUDIT_LOOKBACK_DAYS:-}"
+MERGED_SINCE="${REVIEW_GATE_AUDIT_MERGED_SINCE:-}"
 
 mkdir -p "$(dirname "$OUTPUT")"
+
+resolve_merged_since() {
+  if [ -n "$MERGED_SINCE" ]; then
+    printf '%s' "$MERGED_SINCE"
+    return
+  fi
+
+  if [ -z "$LOOKBACK_DAYS" ] || [ "$LOOKBACK_DAYS" = "all" ]; then
+    return
+  fi
+
+  case "$LOOKBACK_DAYS" in
+    *[!0-9]*)
+      echo "Invalid REVIEW_GATE_AUDIT_LOOKBACK_DAYS: $LOOKBACK_DAYS" >&2
+      exit 2
+      ;;
+  esac
+
+  if date -u -d "${LOOKBACK_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null; then
+    return
+  fi
+
+  if date -u -v-"${LOOKBACK_DAYS}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null; then
+    return
+  fi
+
+  echo "Unable to compute REVIEW_GATE_AUDIT_LOOKBACK_DAYS on this platform" >&2
+  exit 2
+}
+
+MERGED_SINCE="$(resolve_merged_since)"
 
 actors_json="$(
   if [ -n "$OVERRIDE_ACTORS" ]; then
@@ -32,10 +65,14 @@ write_collection_error() {
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg organization "$ORG" \
     --arg reason "$reason" \
+    --arg lookback_days "$LOOKBACK_DAYS" \
+    --arg merged_since "$MERGED_SINCE" \
     '{
       audit_id: $audit_id,
       generated_at: $generated_at,
       organization: $organization,
+      lookback_days: $lookback_days,
+      merged_since: $merged_since,
       passed: false,
       checked: 0,
       violations: [],
@@ -134,8 +171,17 @@ result_json="$(
     --arg audit_id "review-gate-audit" \
     --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     --arg organization "$ORG" \
+    --arg lookback_days "$LOOKBACK_DAYS" \
+    --arg merged_since "$MERGED_SINCE" \
     --argjson actors "$actors_json" \
     '
+      def merged_at($pr):
+        ($pr.mergedAt // $pr.merged_at // "");
+
+      def in_merged_window($pr):
+        ($merged_since == "")
+        or ((merged_at($pr) | fromdateiso8601? // 0) >= ($merged_since | fromdateiso8601? // 0));
+
       def login_of($comment):
         ($comment.author.login // $comment.user.login // "");
 
@@ -163,7 +209,8 @@ result_json="$(
         (.repositories // [])[]
         | (.name // .repo // "") as $repo
         | (.pull_requests // [])[]
-        | select((.mergedAt // .merged_at // "") != "")
+        | select(merged_at(.) != "")
+        | select(in_merged_window(.))
         | select((.reviewDecision // .review_decision // "") == "REVIEW_REQUIRED")
         | select(approved_review_count(.) == 0)
         | override_comment(.) as $override
@@ -172,7 +219,7 @@ result_json="$(
             repo: $repo,
             number: .number,
             url: .url,
-            mergedAt: (.mergedAt // .merged_at // ""),
+            mergedAt: merged_at(.),
             reviewDecision: (.reviewDecision // .review_decision // ""),
             approved_reviews: approved_review_count(.),
             reason: "merged_review_required_without_approval_or_override"
@@ -182,7 +229,8 @@ result_json="$(
         (.repositories // [])[]
         | (.name // .repo // "") as $repo
         | (.pull_requests // [])[]
-        | select((.mergedAt // .merged_at // "") != "")
+        | select(merged_at(.) != "")
+        | select(in_merged_window(.))
         | select((.reviewDecision // .review_decision // "") == "REVIEW_REQUIRED")
         | select(approved_review_count(.) == 0)
         | override_comment(.) as $override
@@ -199,7 +247,8 @@ result_json="$(
       | [
         (.repositories // [])[]
         | (.pull_requests // [])[]
-        | select((.mergedAt // .merged_at // "") != "")
+        | select(merged_at(.) != "")
+        | select(in_merged_window(.))
       ] as $checked_prs
       | [
         (.repositories // [])[]
@@ -210,6 +259,8 @@ result_json="$(
           audit_id: $audit_id,
           generated_at: $generated_at,
           organization: $organization,
+          lookback_days: $lookback_days,
+          merged_since: $merged_since,
           repositories: [(.repositories // [])[] | (.name // .repo // "")],
           passed: (($violations | length) == 0 and ($collection_errors | length) == 0),
           checked: ($checked_prs | length),
@@ -227,6 +278,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "## Review Gate Audit"
     echo ""
     jq -r '"Checked: \(.checked) | Violations: \(.violations | length) | Accounted overrides: \(.accounted_overrides | length)"' "$OUTPUT"
+    jq -r '"Merged since: \((.merged_since // "") | if . == "" then "full audit" else . end)"' "$OUTPUT"
     echo ""
     if jq -e '(.violations | length) > 0' "$OUTPUT" >/dev/null; then
       echo "| Repo | PR | Reason |"

--- a/tests/test-review-gate-audit.sh
+++ b/tests/test-review-gate-audit.sh
@@ -93,6 +93,41 @@ write_override_fixture() {
 JSON
 }
 
+write_mixed_lookback_fixture() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "repositories": [
+    {
+      "name": "hl-dispatch",
+      "pull_requests": [
+        {
+          "number": 180,
+          "url": "https://github.com/huanlongAI/hl-dispatch/pull/180",
+          "title": "fix: historical reviewless merge",
+          "mergedAt": "2026-05-01T10:00:00Z",
+          "reviewDecision": "REVIEW_REQUIRED",
+          "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "reviews": [],
+          "comments": []
+        },
+        {
+          "number": 191,
+          "url": "https://github.com/huanlongAI/hl-dispatch/pull/191",
+          "title": "fix: recent reviewless merge",
+          "mergedAt": "2026-06-04T01:46:46Z",
+          "reviewDecision": "REVIEW_REQUIRED",
+          "headRefOid": "1111111111111111111111111111111111111111",
+          "reviews": [],
+          "comments": []
+        }
+      ]
+    }
+  ]
+}
+JSON
+}
+
 test_reviewless_merge_fails_audit() {
   local tmp output code
   tmp="$(mktemp -d)"
@@ -153,6 +188,30 @@ test_structured_owner_override_accounts_for_reviewless_merge() {
     and .accounted_overrides[0].source == "structured_review_gate_override"
   ' "$tmp/result.json" >/dev/null ||
     fail "structured owner override should account for reviewless merge"
+}
+
+test_merged_since_filters_historical_reviewless_merges() {
+  local tmp code
+  tmp="$(mktemp -d)"
+  write_mixed_lookback_fixture "$tmp/fixture.json"
+
+  set +e
+  REVIEW_GATE_AUDIT_FIXTURE="$tmp/fixture.json" \
+    REVIEW_GATE_AUDIT_OUTPUT="$tmp/result.json" \
+    REVIEW_GATE_AUDIT_MERGED_SINCE="2026-06-04T00:00:00Z" \
+    bash "$SCRIPT" >"$tmp/stdout" 2>"$tmp/stderr"
+  code=$?
+  set -e
+
+  [ "$code" -eq 1 ] || fail "recent reviewless merged PR should still fail audit, got exit $code"
+  jq -e '
+    .passed == false
+    and .merged_since == "2026-06-04T00:00:00Z"
+    and .checked == 1
+    and (.violations | length) == 1
+    and .violations[0].number == 191
+  ' "$tmp/result.json" >/dev/null ||
+    fail "merged_since should exclude historical reviewless merges while keeping recent violations"
 }
 
 test_live_collection_uses_gh_cli_auth_without_token_env() {
@@ -269,10 +328,26 @@ SH
     fail "large PR comment payload should not fail live collection"
 }
 
+test_workflow_exposes_operational_lookback_controls() {
+  local workflow
+  workflow="$ROOT_DIR/.github/workflows/review-gate-audit.yml"
+
+  grep -q 'lookback_days:' "$workflow" ||
+    fail "workflow_dispatch must expose lookback_days"
+  grep -q 'merged_since:' "$workflow" ||
+    fail "workflow_dispatch must expose merged_since"
+  grep -q "REVIEW_GATE_AUDIT_LOOKBACK_DAYS" "$workflow" ||
+    fail "workflow must pass lookback_days to audit script"
+  grep -q "REVIEW_GATE_AUDIT_MERGED_SINCE" "$workflow" ||
+    fail "workflow must pass merged_since to audit script"
+}
+
 test_reviewless_merge_fails_audit
 test_approved_review_passes_audit
 test_structured_owner_override_accounts_for_reviewless_merge
+test_merged_since_filters_historical_reviewless_merges
 test_live_collection_uses_gh_cli_auth_without_token_env
 test_live_collection_handles_large_comment_payload_without_arg_limit
+test_workflow_exposes_operational_lookback_controls
 
 echo "review-gate audit tests passed"


### PR DESCRIPTION
## Summary

- Add `REVIEW_GATE_AUDIT_MERGED_SINCE` and `REVIEW_GATE_AUDIT_LOOKBACK_DAYS` to keep Review Gate Audit usable as a daily operational monitor.
- Keep manual full-audit mode available by setting `lookback_days=all`.
- Record `lookback_days` and `merged_since` in the audit JSON and GitHub step summary for issue ledger evidence.
- Add regression coverage for filtering historical reviewless merges while still failing on recent reviewless merges.

## Why

The default 7-repository audit now runs through large payloads, but a full historical scan produces many legacy reviewless-merge violations. That is useful for proving the systemic problem, but too noisy for day-to-day monitoring. This change lets scheduled runs focus on recent merges while preserving explicit full audit capability.

## Validation

- `bash tests/test-review-gate-audit.sh`
- `git diff --check origin/main..HEAD`
