### PR TITLE
fix(review-gate): expose structured override actors

### DIFF
--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: "2026-06-04T06:36:06Z"
         type: string
+      override_actors:
+        description: Space-separated actors allowed to record structured review gate overrides
+        required: false
+        default: ""
+        type: string
   schedule:
     - cron: '20 1 * * *'
 
@@ -52,4 +57,5 @@ jobs:
           REVIEW_GATE_AUDIT_LOOKBACK_DAYS: ${{ inputs.lookback_days || '7' }}
           REVIEW_GATE_AUDIT_MERGED_SINCE: ${{ inputs.merged_since || '' }}
           REVIEW_GATE_AUDIT_EFFECTIVE_AFTER: ${{ inputs.effective_after || '2026-06-04T06:36:06Z' }}
+          REVIEW_GATE_AUDIT_OVERRIDE_ACTORS: ${{ inputs.override_actors || vars.REVIEW_GATE_AUDIT_OVERRIDE_ACTORS || '' }}
         run: bash scripts/review-gate-audit.sh

--- a/tests/test-review-gate-audit.sh
+++ b/tests/test-review-gate-audit.sh
@@ -119,6 +119,38 @@ write_override_fixture() {
 JSON
 }
 
+write_natural_language_override_fixture() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "repositories": [
+    {
+      "name": "hl-dispatch",
+      "pull_requests": [
+        {
+          "number": 195,
+          "url": "https://github.com/huanlongAI/hl-dispatch/pull/195",
+          "title": "fix: natural language bypass note",
+          "mergedAt": "2026-06-04T08:00:00Z",
+          "reviewDecision": "REVIEW_REQUIRED",
+          "headRefOid": "6666666666666666666666666666666666666666",
+          "reviews": [],
+          "comments": [
+            {
+              "body": "Founder explicitly authorized bypass review gate; checks were green.",
+              "author": {"login": "gate-owner"},
+              "createdAt": "2026-06-04T08:01:00Z",
+              "url": "https://github.com/huanlongAI/hl-dispatch/pull/195#issuecomment-1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+JSON
+}
+
 write_mixed_lookback_fixture() {
   local path="$1"
   cat > "$path" <<'JSON'
@@ -214,6 +246,30 @@ test_structured_owner_override_accounts_for_reviewless_merge() {
     and .accounted_overrides[0].source == "structured_review_gate_override"
   ' "$tmp/result.json" >/dev/null ||
     fail "structured owner override should account for reviewless merge"
+}
+
+test_natural_language_bypass_comment_does_not_account_override() {
+  local tmp code
+  tmp="$(mktemp -d)"
+  write_natural_language_override_fixture "$tmp/fixture.json"
+
+  set +e
+  REVIEW_GATE_AUDIT_FIXTURE="$tmp/fixture.json" \
+    REVIEW_GATE_AUDIT_OUTPUT="$tmp/result.json" \
+    REVIEW_GATE_AUDIT_OVERRIDE_ACTORS="gate-owner" \
+    bash "$SCRIPT" >"$tmp/stdout" 2>"$tmp/stderr"
+  code=$?
+  set -e
+
+  [ "$code" -eq 1 ] || fail "natural language bypass comment must not account reviewless merge, got exit $code"
+  jq -e '
+    .passed == false
+    and (.violations | length) == 1
+    and (.accounted_overrides | length) == 0
+    and .violations[0].repo == "hl-dispatch"
+    and .violations[0].number == 195
+  ' "$tmp/result.json" >/dev/null ||
+    fail "natural language bypass comment should remain a review gate violation"
 }
 
 test_merged_since_filters_historical_reviewless_merges() {
@@ -413,12 +469,18 @@ test_workflow_exposes_operational_review_gate_controls() {
     fail "workflow_dispatch must expose merged_since"
   grep -q 'effective_after:' "$WORKFLOW" ||
     fail "workflow_dispatch must expose effective_after"
+  grep -q 'override_actors:' "$WORKFLOW" ||
+    fail "workflow_dispatch must expose override_actors"
   grep -q "REVIEW_GATE_AUDIT_LOOKBACK_DAYS" "$WORKFLOW" ||
     fail "workflow must pass lookback_days to audit script"
   grep -q "REVIEW_GATE_AUDIT_MERGED_SINCE" "$WORKFLOW" ||
     fail "workflow must pass merged_since to audit script"
   grep -q 'REVIEW_GATE_AUDIT_EFFECTIVE_AFTER:' "$WORKFLOW" ||
     fail "workflow must pass REVIEW_GATE_AUDIT_EFFECTIVE_AFTER"
+  grep -q 'REVIEW_GATE_AUDIT_OVERRIDE_ACTORS:' "$WORKFLOW" ||
+    fail "workflow must pass REVIEW_GATE_AUDIT_OVERRIDE_ACTORS"
+  grep -q 'vars.REVIEW_GATE_AUDIT_OVERRIDE_ACTORS' "$WORKFLOW" ||
+    fail "workflow must support REVIEW_GATE_AUDIT_OVERRIDE_ACTORS repository variable"
   grep -q '2026-06-04T06:36:06Z' "$WORKFLOW" ||
     fail "workflow must default to #117 merge activation time"
 }
@@ -426,6 +488,7 @@ test_workflow_exposes_operational_review_gate_controls() {
 test_reviewless_merge_fails_audit
 test_approved_review_passes_audit
 test_structured_owner_override_accounts_for_reviewless_merge
+test_natural_language_bypass_comment_does_not_account_override
 test_merged_since_filters_historical_reviewless_merges
 test_pre_effective_reviewless_merge_is_accounted_as_legacy
 test_post_effective_reviewless_merge_still_fails_audit


### PR DESCRIPTION
## Summary

- expose `override_actors` as a manual Review Gate Audit input
- allow scheduled/default Review Gate Audit runs to read `vars.REVIEW_GATE_AUDIT_OVERRIDE_ACTORS`
- keep review-gate override accounting strict: natural-language Founder/admin bypass notes do not count unless the structured override comment is present

## Governance context

This supports sentinel-shared#109. Fresh evidence on `hl-dispatch#191` showed a reviewless merge where GitHub reported `REVIEW_REQUIRED` and no PR reviews, while rule-suite evidence showed a candidate merge failed the pull-request rule and the final merge commit passed. The audit path therefore needs a production-configurable, structured owner-reviewed override route instead of relying on natural-language commit messages.

Main ledger: sentinel-shared#111.

## Validation

- `bash tests/test-review-gate-audit.sh`
- `bash tests/test-self-test-workflow.sh`
- `bash tests/test-owner-reviewed-override.sh`
- `git diff --check`