### PR TITLE
[codex] 集中 caller 目标仓库清单

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -19,10 +19,7 @@ permissions:
   contents: read
 
 env:
-  DOWNSTREAM_REPOS: >-
-    tzhOS tzh-Harness tzh-agent-configs tzh-evals tzh-dotfiles
-    tzh-legal tzh-marketing guanghe tzhOS-App super-founder
-    hl-platform hl-framework hl-factory hl-dispatch hl-contracts hl-console-native team-memory
+  TARGET_REPOS_FILE: matrix/caller-target-repos.txt
 
   CANONICAL_BODY: |
     # ============================================================================
@@ -70,6 +67,9 @@ jobs:
   sync-check:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Check caller workflow drift across repos
         id: drift
         env:
@@ -85,6 +85,37 @@ jobs:
           SELECTED_REPOS=""
           INVALID_TARGETS=""
           REPORT=""
+
+          load_downstream_repos() {
+            if [ ! -f "$TARGET_REPOS_FILE" ]; then
+              echo "::error::Caller target repo config missing: ${TARGET_REPOS_FILE}" >&2
+              return 1
+            fi
+
+            { grep -E '^[A-Za-z0-9._-]+$' "$TARGET_REPOS_FILE" || true; } | tr '\n' ' '
+          }
+
+          DOWNSTREAM_REPOS="$(load_downstream_repos)"
+          if [ -z "$DOWNSTREAM_REPOS" ]; then
+            FAILED="empty_target_config,"
+            echo "::error::Caller target repo config contains no targets: ${TARGET_REPOS_FILE}"
+            echo "drifted=" >> "$GITHUB_OUTPUT"
+            echo "drift_count=0" >> "$GITHUB_OUTPUT"
+            echo "synced=" >> "$GITHUB_OUTPUT"
+            echo "missing=" >> "$GITHUB_OUTPUT"
+            echo "failed=${FAILED}" >> "$GITHUB_OUTPUT"
+            echo "failed_count=1" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Caller Workflow Sync Report"
+              echo ""
+              echo "Mode: $( [ "$DRY_RUN" = "true" ] && echo 'DRY RUN (preview only)' || echo 'LIVE (PRs created)')"
+              echo "Targets: ${TARGET_REPOS_INPUT:-from ${TARGET_REPOS_FILE}}"
+              echo "Synced: 0 | Drifted: 0 | Missing: 0 | Failed: 1"
+              echo ""
+              echo "Failed targets: ${FAILED%,}"
+            } > /tmp/sync-report.md
+            exit 0
+          fi
 
           if [ -z "$TARGET_REPOS_INPUT" ]; then
             SELECTED_REPOS="$DOWNSTREAM_REPOS"

--- a/.github/workflows/caller-token-write-probe.yml
+++ b/.github/workflows/caller-token-write-probe.yml
@@ -4,17 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       target_repo:
-        description: Huanlong downstream repo to probe
+        description: Caller target repo to probe
         required: true
-        type: choice
-        options:
-          - hl-platform
-          - hl-framework
-          - hl-factory
-          - hl-dispatch
-          - hl-contracts
-          - hl-console-native
-          - team-memory
+        type: string
       cleanup:
         description: Delete the temporary probe branch after the run
         required: false
@@ -28,13 +20,16 @@ jobs:
   workflow-file-write-probe:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Probe CASCADE_TOKEN workflow-file write permission
         env:
           GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
           TARGET_REPO: ${{ inputs.target_repo }}
+          TARGET_REPOS_FILE: matrix/caller-target-repos.txt
           CLEANUP: ${{ github.event.inputs.cleanup || 'true' }}
           RUN_ID: ${{ github.run_id }}
-          HUANLONG_PROBE_REPOS: "hl-platform hl-framework hl-factory hl-dispatch hl-contracts hl-console-native team-memory"
           PROBE_BRANCH_PREFIX: sentinel-token-write-probe
           TOKEN_REMEDIATION: "CASCADE_TOKEN must have repo read/write access and workflow write permission for the selected downstream repo."
         run: |
@@ -61,6 +56,22 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           }
 
+          load_probe_targets() {
+            if [ ! -f "$TARGET_REPOS_FILE" ]; then
+              echo "::error::Caller target repo config missing: ${TARGET_REPOS_FILE}" >&2
+              return 1
+            fi
+
+            { grep -E '^[A-Za-z0-9._-]+$' "$TARGET_REPOS_FILE" || true; } | tr '\n' ' '
+          }
+
+          PROBE_TARGETS="$(load_probe_targets)"
+          if [ -z "$PROBE_TARGETS" ]; then
+            FAILURE_REASON="empty_target_config"
+            echo "::error::Caller target repo config contains no targets: ${TARGET_REPOS_FILE}"
+            exit 1
+          fi
+
           cleanup_branch() {
             if [ "$BRANCH_CREATED" != "true" ]; then
               write_summary
@@ -82,7 +93,7 @@ jobs:
           }
           trap cleanup_branch EXIT
 
-          case " ${HUANLONG_PROBE_REPOS} " in
+          case " ${PROBE_TARGETS} " in
             *" ${TARGET_REPO} "*)
               ;;
             *)

--- a/matrix/caller-target-repos.txt
+++ b/matrix/caller-target-repos.txt
@@ -1,0 +1,19 @@
+# Caller workflow target repos.
+# One repo name per line, without owner. Workflows read this file at runtime.
+tzhOS
+tzh-Harness
+tzh-agent-configs
+tzh-evals
+tzh-dotfiles
+tzh-legal
+tzh-marketing
+guanghe
+tzhOS-App
+super-founder
+hl-platform
+hl-framework
+hl-factory
+hl-dispatch
+hl-contracts
+hl-console-native
+team-memory

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -3,11 +3,18 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CALLER_SYNC_WORKFLOW="$ROOT_DIR/.github/workflows/caller-sync.yml"
+TARGETS_FILE="$ROOT_DIR/matrix/caller-target-repos.txt"
 
 fail() {
   echo "FAIL: $*" >&2
   exit 1
 }
+
+[ -f "$TARGETS_FILE" ] || fail "caller target repo config must exist"
+
+if ! grep -Eq '^[A-Za-z0-9._-]+$' "$TARGETS_FILE"; then
+  fail "caller target repo config must contain at least one plain repo name"
+fi
 
 if grep -q '\${{ inputs\.dry_run || '\''true'\'' }}' "$CALLER_SYNC_WORKFLOW"; then
   fail "caller-sync must not coerce boolean false dry_run input back to true"
@@ -43,6 +50,10 @@ for expected in \
   '@main reusable workflow reference is intentional for this thin caller projection.' \
   'LLM provider credentials are consumed only by sentinel-shared provider router.' \
   'HeiyuCode is preferred when configured; Anthropic remains the fallback provider.' \
+  'actions/checkout@v5' \
+  'TARGET_REPOS_FILE: matrix/caller-target-repos.txt' \
+  'load_downstream_repos()' \
+  'DOWNSTREAM_REPOS="$(load_downstream_repos)"' \
   'target_repos:' \
   'TARGET_REPOS_INPUT=' \
   'SELECTED_REPOS=' \
@@ -67,6 +78,17 @@ for expected in \
 do
   grep -q "$expected" "$CALLER_SYNC_WORKFLOW" \
     || fail "caller-sync workflow missing failure-handling marker: $expected"
+done
+
+for forbidden in \
+  'DOWNSTREAM_REPOS: >-' \
+  'tzhOS tzh-Harness tzh-agent-configs' \
+  'hl-platform hl-framework hl-factory' \
+  'hl-dispatch hl-contracts hl-console-native team-memory'
+do
+  if grep -Fq "$forbidden" "$CALLER_SYNC_WORKFLOW"; then
+    fail "caller-sync workflow must not hardcode target repo list: $forbidden"
+  fi
 done
 
 for expected in \

--- a/tests/test-caller-token-write-probe-workflow.sh
+++ b/tests/test-caller-token-write-probe-workflow.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/caller-token-write-probe.yml"
+TARGETS_FILE="$ROOT_DIR/matrix/caller-target-repos.txt"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -10,22 +11,22 @@ fail() {
 }
 
 [ -f "$WORKFLOW" ] || fail "caller token write probe workflow must exist"
+[ -f "$TARGETS_FILE" ] || fail "caller target repo config must exist"
+
+if ! grep -Eq '^[A-Za-z0-9._-]+$' "$TARGETS_FILE"; then
+  fail "caller target repo config must contain at least one plain repo name"
+fi
 
 for expected in \
   'name: Caller Token Write Probe' \
   'workflow_dispatch:' \
   'target_repo:' \
-  'type: choice' \
-  'hl-platform' \
-  'hl-framework' \
-  'hl-factory' \
-  'hl-dispatch' \
-  'hl-contracts' \
-  'hl-console-native' \
-  'team-memory' \
+  'type: string' \
   'GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}' \
+  'TARGET_REPOS_FILE: matrix/caller-target-repos.txt' \
   "CLEANUP: \${{ github.event.inputs.cleanup || 'true' }}" \
-  'HUANLONG_PROBE_REPOS:' \
+  'load_probe_targets()' \
+  'PROBE_TARGETS="$(load_probe_targets)"' \
   'PROBE_BRANCH="${PROBE_BRANCH_PREFIX}-${RUN_ID}"' \
   'PROBE_PATH=".github/workflows/sentinel-token-write-probe-${RUN_ID}.yml"' \
   'BRANCH_CREATED="false"' \
@@ -49,8 +50,18 @@ if grep -Fq "CLEANUP: \${{ inputs.cleanup || 'true' }}" "$WORKFLOW"; then
 fi
 
 for forbidden in \
+  'type: choice' \
+  'options:' \
+  'HUANLONG_PROBE_REPOS' \
   'tzhOS' \
   'super-founder' \
+  'hl-platform' \
+  'hl-framework' \
+  'hl-factory' \
+  'hl-dispatch' \
+  'hl-contracts' \
+  'hl-console-native' \
+  'team-memory' \
   '/pulls' \
   'sentinel-caller-sync'
 do


### PR DESCRIPTION
## Summary

- 新增 `matrix/caller-target-repos.txt`，作为 caller-sync 与 caller-token-write-probe 的共享目标仓库清单。
- `caller-sync.yml` 不再内联 `DOWNSTREAM_REPOS` 固定列表，运行时 checkout 后读取共享清单。
- `caller-token-write-probe.yml` 不再使用 GitHub Actions `choice` 固定 options 或 `HUANLONG_PROBE_REPOS`，改为 string input + 共享清单校验。
- 更新回归测试，禁止 workflow 重新内联目标 repo 列表。

## Why

避免 caller-sync / token probe 在 workflow 逻辑内硬编码目标仓库，降低后续仓库地图变化时的维护漂移风险。

## Verification

- `bash tests/test-caller-token-write-probe-workflow.sh && bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-policy-file.sh && bash tests/test-d7-d8.sh && bash tests/test-caller-sync-workflow.sh && bash tests/test-caller-token-write-probe-workflow.sh && bash tests/test-dashboard-workflow.sh && bash tests/test-cascade-workflow.sh && bash tests/test-llm-review-provider-router.sh && bash tests/test-llm-message-client.sh && bash tests/test-aux-llm-workflows.sh && bash tests/test-owner-reviewed-override.sh && bash tests/test-review-gate-audit.sh && bash tests/test-agent-governance.sh && bash tests/test-self-test-workflow.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'`
- `git diff --check origin/main...HEAD`

## Note

这不改变 `CASCADE_TOKEN` 的实际权限；workflow-file write probe 仍会如实暴露 token scope / repo access 问题。
