### PR TITLE
fix(review-gate): report collection errors

### DIFF
--- a/scripts/review-gate-audit.sh
+++ b/scripts/review-gate-audit.sh
@@ -320,6 +320,12 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
       echo "|---|---:|---|"
       jq -r '.violations[] | "| \(.repo) | [#\(.number)](\(.url)) | \(.reason) |"' "$OUTPUT"
     fi
+    if jq -e '(.collection_errors | length) > 0' "$OUTPUT" >/dev/null; then
+      echo ""
+      echo "| Repo | Collection error |"
+      echo "|---|---|"
+      jq -r '.collection_errors[] | "| \(.repo) | \((.reason // "") | gsub("[\r\n]+"; " ")) |"' "$OUTPUT"
+    fi
   } >> "$GITHUB_STEP_SUMMARY"
 fi
 
@@ -330,4 +336,5 @@ fi
 
 echo "Review gate audit failed"
 jq -r '.violations[]? | "::error::\(.repo)#\(.number) \(.reason)"' "$OUTPUT"
+jq -r '.collection_errors[]? | "::error::\(.repo) collection_error \((.reason // "") | gsub("[\r\n]+"; " "))"' "$OUTPUT"
 exit 1

--- a/tests/test-review-gate-audit.sh
+++ b/tests/test-review-gate-audit.sh
@@ -186,6 +186,21 @@ write_mixed_lookback_fixture() {
 JSON
 }
 
+write_collection_error_fixture() {
+  local path="$1"
+  cat > "$path" <<'JSON'
+{
+  "repositories": [
+    {
+      "name": "hl-platform",
+      "pull_requests": [],
+      "collection_error": "HTTP 404: Resource not accessible by token"
+    }
+  ]
+}
+JSON
+}
+
 test_reviewless_merge_fails_audit() {
   local tmp output code
   tmp="$(mktemp -d)"
@@ -208,6 +223,29 @@ test_reviewless_merge_fails_audit() {
     and .violations[0].reason == "merged_review_required_without_approval_or_override"
   ' "$tmp/result.json" >/dev/null ||
     fail "reviewless merge violation was not recorded"
+}
+
+test_collection_errors_are_reported_in_logs() {
+  local tmp code
+  tmp="$(mktemp -d)"
+  write_collection_error_fixture "$tmp/fixture.json"
+
+  set +e
+  REVIEW_GATE_AUDIT_FIXTURE="$tmp/fixture.json" \
+    REVIEW_GATE_AUDIT_OUTPUT="$tmp/result.json" \
+    bash "$SCRIPT" >"$tmp/stdout" 2>"$tmp/stderr"
+  code=$?
+  set -e
+
+  [ "$code" -eq 1 ] || fail "collection error should fail audit, got exit $code"
+  jq -e '
+    .passed == false
+    and (.collection_errors | length) == 1
+    and .collection_errors[0].repo == "hl-platform"
+  ' "$tmp/result.json" >/dev/null ||
+    fail "collection error should be recorded in JSON output"
+  grep -Fq "::error::hl-platform collection_error HTTP 404: Resource not accessible by token" "$tmp/stdout" ||
+    fail "collection error should be emitted as a GitHub error log"
 }
 
 test_approved_review_passes_audit() {
@@ -486,6 +524,7 @@ test_workflow_exposes_operational_review_gate_controls() {
 }
 
 test_reviewless_merge_fails_audit
+test_collection_errors_are_reported_in_logs
 test_approved_review_passes_audit
 test_structured_owner_override_accounts_for_reviewless_merge
 test_natural_language_bypass_comment_does_not_account_override


### PR DESCRIPTION
## Summary

- 让 Review Gate Audit 在 collection_errors 存在时输出 GitHub error log。
- 在 Step Summary 中展示 collection error 表，避免远端只看到 exit 1。
- 增加回归测试覆盖 collection error 日志输出。

## Verification

- bash tests/test-review-gate-audit.sh
- bash tests/test-self-test-workflow.sh
- git diff --check

## Notes

关联主任务：#111。该 PR 只修诊断输出，不放宽 review gate 判定。