### PR TITLE
fix(review-gate): 使用专用审计读取 token

### DIFF
--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Audit merged PR review gate evidence
         env:
-          GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
+          GH_TOKEN: ${{ secrets.REVIEW_GATE_AUDIT_TOKEN || secrets.CASCADE_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
           REVIEW_GATE_AUDIT_REPOS: ${{ inputs.repos || 'hl-platform hl-framework hl-factory hl-dispatch hl-contracts hl-console-native team-memory' }}
           REVIEW_GATE_AUDIT_LIMIT: ${{ inputs.limit || '30' }}

--- a/tests/test-review-gate-audit.sh
+++ b/tests/test-review-gate-audit.sh
@@ -586,6 +586,8 @@ test_workflow_exposes_operational_review_gate_controls() {
     fail "workflow must pass REVIEW_GATE_AUDIT_OVERRIDE_ACTORS"
   grep -q 'vars.REVIEW_GATE_AUDIT_OVERRIDE_ACTORS' "$WORKFLOW" ||
     fail "workflow must support REVIEW_GATE_AUDIT_OVERRIDE_ACTORS repository variable"
+  grep -Fq 'GH_TOKEN: ${{ secrets.REVIEW_GATE_AUDIT_TOKEN || secrets.CASCADE_TOKEN }}' "$WORKFLOW" ||
+    fail "workflow must prefer dedicated REVIEW_GATE_AUDIT_TOKEN and fall back to CASCADE_TOKEN"
   grep -q '2026-06-04T06:36:06Z' "$WORKFLOW" ||
     fail "workflow must default to #117 merge activation time"
 }


### PR DESCRIPTION
## 背景

#131 暴露出 `CASCADE_TOKEN` 的权限职责耦合：它已验证 workflow-file write，但 Review Gate Audit 仍需要跨仓 PR / comment read。继续把两类权限绑在一个 token 上会让 #17 和 #131 互相牵制。

## 变更

- `Review Gate Audit` 优先使用 `secrets.REVIEW_GATE_AUDIT_TOKEN`。
- 未配置专用 token 时 fallback 到 `secrets.CASCADE_TOKEN`，保持向后兼容。
- 增加 workflow shape test，防止后续回退为单一 `CASCADE_TOKEN`。

## 验证

- `bash tests/test-review-gate-audit.sh` passed
- `bash tests/test-self-test-workflow.sh` passed
- `git diff --check` clean

## 后续生产验证

合并后配置 `REVIEW_GATE_AUDIT_TOKEN` repo secret，并重跑：

1. `Review Gate Audit` 单仓 `hl-platform`
2. 默认 7 仓 audit

不在 PR、Issue 或日志中公开任何 token / secret 值。

Refs #131
Refs #111