### PR TITLE
[codex] 修复 Cascade 结果收集 API 错误可观测性

### DIFF
--- a/.github/workflows/cascade-verify.yml
+++ b/.github/workflows/cascade-verify.yml
@@ -130,15 +130,25 @@ jobs:
             PASS=0
             FAIL=0
             SKIP=0
+            API_ERROR=0
             REPORT=""
 
             for REPO in $DOWNSTREAM_REPOS; do
               # Get the most recent sentinel workflow run
-              RUN_DATA=$(curl -s \
+              RUN_RESPONSE_FILE="$(mktemp)"
+              RUN_HTTP_STATUS=$(curl -sS -o "$RUN_RESPONSE_FILE" -w "%{http_code}" \
                 -H "Authorization: token ${GH_TOKEN}" \
                 -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/huanlongAI/${REPO}/actions/runs?per_page=3&event=repository_dispatch" \
-                | jq -r '.workflow_runs[0] // empty')
+                "https://api.github.com/repos/huanlongAI/${REPO}/actions/runs?per_page=3&event=repository_dispatch")
+
+              if [ "$RUN_HTTP_STATUS" != "200" ]; then
+                REPORT="${REPORT}| ${REPO} | ❌ api_error | actions/runs HTTP ${RUN_HTTP_STATUS} |\n"
+                FAIL=$((FAIL + 1))
+                API_ERROR=$((API_ERROR + 1))
+                continue
+              fi
+
+              RUN_DATA=$(jq -r '.workflow_runs[0] // empty' "$RUN_RESPONSE_FILE")
 
               if [ -z "$RUN_DATA" ]; then
                 REPORT="${REPORT}| ${REPO} | ⏭️ skip | No dispatch run found |\n"
@@ -166,7 +176,7 @@ jobs:
             done
 
             echo "Cascade poll: pass=${PASS}, fail=${FAIL}, skip=${SKIP}"
-            if [ "$SKIP" -eq 0 ] || [ "$SECONDS" -ge "$deadline" ]; then
+            if [ "$API_ERROR" -gt 0 ] || [ "$SKIP" -eq 0 ] || [ "$SECONDS" -ge "$deadline" ]; then
               break
             fi
 
@@ -201,14 +211,20 @@ jobs:
           GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
         run: |
           BODY=$(cat /tmp/cascade-summary.md)
-          curl -s -X POST \
+          ISSUE_HTTP_STATUS=$(curl -sS -o /tmp/cascade-issue-response.json -w "%{http_code}" -X POST \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/huanlongAI/sentinel-shared/issues" \
             -d "$(jq -n \
               --arg title "🚨 Cascade Verification: ${{ steps.results.outputs.fail }} failed / ${{ steps.results.outputs.skip }} incomplete" \
               --arg body "$BODY" \
-              '{title: $title, body: $body, labels: ["cascade-failure"]}')"
+              '{title: $title, body: $body, labels: ["cascade-failure"]}')")
+
+          if [ "$ISSUE_HTTP_STATUS" != "201" ]; then
+            echo "::error::Cascade failure issue creation failed: HTTP ${ISSUE_HTTP_STATUS}"
+            cat /tmp/cascade-issue-response.json
+            exit 1
+          fi
 
       - name: Output summary
         if: always()

--- a/tests/test-cascade-workflow.sh
+++ b/tests/test-cascade-workflow.sh
@@ -30,9 +30,15 @@ assert_contains "$workflow" 'CASCADE_WAIT_TIMEOUT_SECONDS="${CASCADE_WAIT_TIMEOU
 assert_contains "$workflow" 'CASCADE_POLL_INTERVAL_SECONDS="${CASCADE_POLL_INTERVAL_SECONDS:-20}"'
 assert_contains "$workflow" 'deadline=$((SECONDS + CASCADE_WAIT_TIMEOUT_SECONDS))'
 assert_contains "$workflow" 'while true; do'
-assert_contains "$workflow" 'if [ "$SKIP" -eq 0 ] || [ "$SECONDS" -ge "$deadline" ]; then'
+assert_contains "$workflow" 'API_ERROR=0'
+assert_contains "$workflow" 'curl -sS -o "$RUN_RESPONSE_FILE" -w "%{http_code}"'
+assert_contains "$workflow" 'actions/runs HTTP ${RUN_HTTP_STATUS}'
+assert_contains "$workflow" 'if [ "$API_ERROR" -gt 0 ] || [ "$SKIP" -eq 0 ] || [ "$SECONDS" -ge "$deadline" ]; then'
 assert_contains "$workflow" 'if [ -n "$DISPATCH_FAILED" ] || [ "$FAIL" -gt 0 ] || [ "$SKIP" -gt 0 ]; then'
 assert_contains "$workflow" '::error::Cascade verification incomplete or failed:'
+assert_contains "$workflow" 'ISSUE_HTTP_STATUS=$(curl -sS -o /tmp/cascade-issue-response.json -w "%{http_code}"'
+assert_contains "$workflow" 'if [ "$ISSUE_HTTP_STATUS" != "201" ]; then'
+assert_contains "$workflow" '::error::Cascade failure issue creation failed: HTTP ${ISSUE_HTTP_STATUS}'
 assert_contains "$workflow" "always() && (steps.results.outputs.fail != '0' || steps.results.outputs.skip != '0' || needs.fan-out.outputs.failed != '')"
 assert_contains "$workflow" "if: always()"
 


### PR DESCRIPTION
## 背景

合并 #133 后的 Cascade Verification run `26993869629` 中，fan-out 成功，但 collect-results 等待 15 分钟后失败，仅给出 `pass=2, skip=15`。旧逻辑没有读取 `actions/runs` API 的 HTTP 状态，权限/API 错误会被误当作没有 dispatch run。

同时，failure issue 创建步骤只看 shell exit code，不校验 GitHub Issues API 是否返回 201，可能出现步骤成功但实际没有创建告警 issue 的情况。

## 变更

- Collect downstream results 时用响应文件 + HTTP 状态码读取 `actions/runs`。
- 非 200 状态记为 `api_error` 并 fail fast，不再等满 900 秒。
- 创建 cascade failure issue 时校验 HTTP 201；失败时输出响应并让步骤失败。
- 增加 workflow shape test，防止后续退回静默 skip。

## 验证

- `bash tests/test-cascade-workflow.sh`
- `bash tests/test-self-test-workflow.sh`
- `git diff --check`