### PR TITLE
[codex] 拆分 Cascade 结果读取 token 并校验告警标签

### DIFF
--- a/.github/workflows/cascade-verify.yml
+++ b/.github/workflows/cascade-verify.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Collect downstream results
         id: results
         env:
-          GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
+          GH_TOKEN: ${{ secrets.CASCADE_RESULTS_TOKEN || secrets.CASCADE_TOKEN }}
         run: |
           CASCADE_WAIT_TIMEOUT_SECONDS="${CASCADE_WAIT_TIMEOUT_SECONDS:-900}"
           CASCADE_POLL_INTERVAL_SECONDS="${CASCADE_POLL_INTERVAL_SECONDS:-20}"
@@ -208,7 +208,7 @@ jobs:
       - name: Create issue if failures detected
         if: always() && (steps.results.outputs.fail != '0' || steps.results.outputs.skip != '0' || needs.fan-out.outputs.failed != '')
         env:
-          GH_TOKEN: ${{ secrets.CASCADE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           BODY=$(cat /tmp/cascade-summary.md)
           ISSUE_HTTP_STATUS=$(curl -sS -o /tmp/cascade-issue-response.json -w "%{http_code}" -X POST \
@@ -222,6 +222,12 @@ jobs:
 
           if [ "$ISSUE_HTTP_STATUS" != "201" ]; then
             echo "::error::Cascade failure issue creation failed: HTTP ${ISSUE_HTTP_STATUS}"
+            cat /tmp/cascade-issue-response.json
+            exit 1
+          fi
+
+          if ! jq -e '.labels[]? | select(.name == "cascade-failure")' /tmp/cascade-issue-response.json >/dev/null; then
+            echo "::error::Cascade failure issue was created without cascade-failure label"
             cat /tmp/cascade-issue-response.json
             exit 1
           fi

--- a/tests/test-cascade-workflow.sh
+++ b/tests/test-cascade-workflow.sh
@@ -30,6 +30,7 @@ assert_contains "$workflow" 'CASCADE_WAIT_TIMEOUT_SECONDS="${CASCADE_WAIT_TIMEOU
 assert_contains "$workflow" 'CASCADE_POLL_INTERVAL_SECONDS="${CASCADE_POLL_INTERVAL_SECONDS:-20}"'
 assert_contains "$workflow" 'deadline=$((SECONDS + CASCADE_WAIT_TIMEOUT_SECONDS))'
 assert_contains "$workflow" 'while true; do'
+assert_contains "$workflow" 'GH_TOKEN: ${{ secrets.CASCADE_RESULTS_TOKEN || secrets.CASCADE_TOKEN }}'
 assert_contains "$workflow" 'API_ERROR=0'
 assert_contains "$workflow" 'curl -sS -o "$RUN_RESPONSE_FILE" -w "%{http_code}"'
 assert_contains "$workflow" 'actions/runs HTTP ${RUN_HTTP_STATUS}'
@@ -39,6 +40,9 @@ assert_contains "$workflow" '::error::Cascade verification incomplete or failed:
 assert_contains "$workflow" 'ISSUE_HTTP_STATUS=$(curl -sS -o /tmp/cascade-issue-response.json -w "%{http_code}"'
 assert_contains "$workflow" 'if [ "$ISSUE_HTTP_STATUS" != "201" ]; then'
 assert_contains "$workflow" '::error::Cascade failure issue creation failed: HTTP ${ISSUE_HTTP_STATUS}'
+assert_contains "$workflow" 'GH_TOKEN: ${{ github.token }}'
+assert_contains "$workflow" 'jq -e '\''.labels[]? | select(.name == "cascade-failure")'\'' /tmp/cascade-issue-response.json'
+assert_contains "$workflow" '::error::Cascade failure issue was created without cascade-failure label'
 assert_contains "$workflow" "always() && (steps.results.outputs.fail != '0' || steps.results.outputs.skip != '0' || needs.fan-out.outputs.failed != '')"
 assert_contains "$workflow" "if: always()"
 


### PR DESCRIPTION
## 背景

最新 main 手动触发 `Cascade Verification` run `26995003957` 后，fan-out 成功，但 collect-results 对 15 个下游仓读取 `actions/runs` 返回 HTTP 403。#136 已经让错误快速暴露，但结果读取职责仍然复用 `CASCADE_TOKEN`。

同一轮还创建了 #137，但 issue 没有挂上 `cascade-failure` label，说明 issue 创建响应需要校验实际标签状态。

## 变更

- Cascade collect-results 优先使用 `secrets.CASCADE_RESULTS_TOKEN`，未配置时 fallback 到 `secrets.CASCADE_TOKEN`。
- Cascade failure issue 创建改用当前仓 `github.token`，避免跨仓 cascade token 与本仓告警写入耦合。
- issue 创建后校验响应里必须包含 `cascade-failure` label，否则 fail closed。
- 增加 workflow shape test，锁住 token 分工与 label 校验。

## 验证

- `bash tests/test-cascade-workflow.sh`
- `bash tests/test-self-test-workflow.sh`
- `git diff --check`

## 后续生产配置

需要配置 `CASCADE_RESULTS_TOKEN` repo secret，权限至少覆盖下游目标仓的 `Actions: read`。未配置时 workflow 会 fallback 到 `CASCADE_TOKEN`，仍可能在私有仓 `actions/runs` 读取处返回 403。

Refs #137
Refs #111