### PR TITLE
[codex] sentinel: 新增 GitHub 中文语言门禁

### DIFF
--- a/.github/workflows/github-language-gate.yml
+++ b/.github/workflows/github-language-gate.yml
@@ -1,0 +1,62 @@
+name: GitHub Language Gate
+
+on:
+  workflow_call:
+    inputs:
+      enforcement_mode:
+        description: "audit or enforce"
+        required: false
+        default: audit
+        type: string
+      report_comment:
+        description: "Post a Chinese issue comment when the gate reports a violation"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  github-language-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout shared language gate
+        uses: actions/checkout@v5
+        with:
+          repository: huanlongAI/sentinel-shared
+          path: .sentinel-shared
+          token: ${{ github.token }}
+
+      - name: Check GitHub issue/comment Chinese language
+        id: language_gate
+        continue-on-error: true
+        run: |
+          python3 .sentinel-shared/scripts/check-github-language-gate.py \
+            --event-path "$GITHUB_EVENT_PATH" \
+            --enforcement-mode "${{ inputs.enforcement_mode }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Report Chinese language gate violation
+        if: inputs.report_comment && steps.language_gate.outputs.status != 'passed' && steps.language_gate.outputs.target_issue_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GATE_ERRORS: ${{ steps.language_gate.outputs.errors }}
+          GATE_STATUS: ${{ steps.language_gate.outputs.status }}
+          GATE_TARGET_URL: ${{ steps.language_gate.outputs.target_url }}
+          GATE_WARNINGS: ${{ steps.language_gate.outputs.warnings }}
+          ISSUE_NUMBER: ${{ steps.language_gate.outputs.target_issue_number }}
+        run: |
+          cat > "$RUNNER_TEMP/github-language-gate-comment.md" <<EOF
+          ## 中文门禁未通过
+
+          检测目标：$GATE_TARGET_URL
+
+          门禁状态：$GATE_STATUS
+
+          错误码：$GATE_ERRORS$GATE_WARNINGS
+
+          请将 Issue（事项）标题、正文或评论补充简体中文说明后重新编辑。英文术语、命令、路径、字段名和日志可以保留，但不能提交纯英文内容。
+          EOF
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/github-language-gate-comment.md"
+
+      - name: Fail Chinese language gate
+        if: steps.language_gate.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -51,6 +51,8 @@ jobs:
           bash tests/test-owner-reviewed-override.sh
           bash tests/test-review-gate-audit.sh
           bash tests/test-agent-governance.sh
+          python3 tests/test-github-language-gate.py
+          bash tests/test-github-language-gate-workflow.sh
           bash tests/test-self-test-workflow.sh
 
       - name: Check shell syntax

--- a/matrix/sentinel-matrix.yaml
+++ b/matrix/sentinel-matrix.yaml
@@ -121,6 +121,15 @@ dimensions:
         trigger: "AGENTS.md / CLAUDE.md / agent runtime projection 变更"
         phase: 1
 
+      - id: GPC-008
+        name: "GitHub 对外回复语言门禁"
+        severity: P0
+        method: deterministic
+        precheck_id: D-11
+        source: "Founder 2026-06-05 Codex 裁决 / CONSEN-SPEC-001 language gate intent"
+        trigger: "GitHub Issue / issue_comment / gate-generated comment"
+        phase: 1
+
   design_brand:
     id: DBC
     name: "设计与品牌一致性"
@@ -211,6 +220,10 @@ prechecks:
     script: precheck-agent-governance.sh
     check_ids: [GPC-007]
     description: "Agent 治理投影漂移检查"
+  D-11:
+    script: check-github-language-gate.py
+    check_ids: [GPC-008]
+    description: "GitHub Issue / Comment 简体中文语言门禁"
 
 # LLM configuration
 llm:

--- a/scripts/check-github-language-gate.py
+++ b/scripts/check-github-language-gate.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]")
+LATIN_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+URL_RE = re.compile(r"https?://\S+")
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+ISSUE_URL_RE = re.compile(r"/issues/(\d+)(?:#|$)")
+
+MIN_BODY_CJK_CHARS = 6
+MIN_BODY_CJK_RATIO = 0.2
+LATIN_HEAVY_WORDS = 12
+
+OWNER_CONFIRMATION_ROOTS = (
+    "owner_confirmation_response_v1:",
+    "frontend_owner_confirmation:",
+)
+INTERNAL_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def has_chinese(text):
+    return bool(CJK_RE.search(text or ""))
+
+
+def chinese_signal_too_weak(text):
+    normalized = URL_RE.sub(" ", text or "")
+    cjk_count = len(CJK_RE.findall(normalized))
+    if cjk_count == 0:
+        return False
+
+    prose_for_latin_count = FENCED_CODE_BLOCK_RE.sub(" ", normalized)
+    latin_word_count = len(LATIN_WORD_RE.findall(prose_for_latin_count))
+    if latin_word_count < LATIN_HEAVY_WORDS:
+        return False
+
+    cjk_ratio = cjk_count / (cjk_count + latin_word_count)
+    return cjk_count < MIN_BODY_CJK_CHARS or cjk_ratio < MIN_BODY_CJK_RATIO
+
+
+def is_structured_owner_yaml(text):
+    stripped = (text or "").lstrip()
+    return any(stripped.startswith(root) for root in OWNER_CONFIRMATION_ROOTS)
+
+
+def actor_scope(event, target):
+    user_type = ((target.get("user") or {}).get("type") or "").lower()
+    if user_type == "bot":
+        return "internal"
+
+    association = (target.get("author_association") or "").upper()
+    if association in INTERNAL_ASSOCIATIONS:
+        return "internal"
+    if association:
+        return "external"
+    return "internal"
+
+
+def validate_issue(issue):
+    errors = []
+    title = issue.get("title") or ""
+    body = issue.get("body") or ""
+
+    if not has_chinese(title):
+        errors.append("title_missing_chinese")
+    if body.strip() and not has_chinese(body):
+        errors.append("body_missing_chinese")
+    elif body.strip() and chinese_signal_too_weak(body):
+        errors.append("body_chinese_ratio_too_low")
+
+    return {
+        "kind": "issue",
+        "target_url": issue.get("html_url") or "",
+        "structured_yaml_allowed": False,
+        "violations": errors,
+    }
+
+
+def validate_comment(comment):
+    body = comment.get("body") or ""
+    structured_yaml_allowed = is_structured_owner_yaml(body)
+    errors = []
+
+    if not structured_yaml_allowed and not has_chinese(body):
+        errors.append("comment_missing_chinese")
+    elif not structured_yaml_allowed and chinese_signal_too_weak(body):
+        errors.append("comment_chinese_ratio_too_low")
+
+    return {
+        "kind": "issue_comment",
+        "target_url": comment.get("html_url") or "",
+        "structured_yaml_allowed": structured_yaml_allowed,
+        "violations": errors,
+    }
+
+
+def validate_event(event, enforcement_mode):
+    if "comment" in event:
+        target = event.get("comment") or {}
+        result = validate_comment(target)
+    elif "issue" in event:
+        target = event.get("issue") or {}
+        result = validate_issue(target)
+    else:
+        target = {}
+        result = {
+            "kind": "unsupported",
+            "target_url": "",
+            "structured_yaml_allowed": False,
+            "violations": ["unsupported_event_payload"],
+        }
+
+    scope = actor_scope(event, target)
+    violations = result.pop("violations")
+    if violations and scope == "external":
+        status = "warn"
+        errors = []
+        warnings = violations
+    elif violations:
+        status = "failed"
+        errors = violations
+        warnings = []
+    else:
+        status = "passed"
+        errors = []
+        warnings = []
+
+    result.update(
+        {
+            "actor_scope": scope,
+            "audit_mode": enforcement_mode == "audit",
+            "enforcement_mode": enforcement_mode,
+            "errors": errors,
+            "status": status,
+            "target_issue_number": target_issue_number(event, result["target_url"]),
+            "warnings": warnings,
+        }
+    )
+    return result
+
+
+def target_issue_number(event, target_url):
+    issue = event.get("issue") or {}
+    number = issue.get("number")
+    if number is not None:
+        return str(number)
+
+    match = ISSUE_URL_RE.search(target_url or "")
+    if match:
+        return match.group(1)
+
+    return ""
+
+
+def write_github_output(output_path, result):
+    values = {
+        "actor_scope": result["actor_scope"],
+        "errors": ",".join(result["errors"]),
+        "status": result["status"],
+        "target_issue_number": result["target_issue_number"],
+        "target_url": result["target_url"],
+        "warnings": ",".join(result["warnings"]),
+    }
+    with Path(output_path).open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value}\n")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Check GitHub issue/comment Chinese language gate")
+    parser.add_argument("--event-path", required=True)
+    parser.add_argument("--enforcement-mode", choices=("audit", "enforce"), default="audit")
+    parser.add_argument("--github-output")
+    args = parser.parse_args(argv)
+
+    event = json.loads(Path(args.event_path).read_text(encoding="utf-8"))
+    result = validate_event(event, args.enforcement_mode)
+    if args.github_output:
+        write_github_output(args.github_output, result)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+
+    if args.enforcement_mode == "enforce" and result["status"] == "failed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -643,6 +643,16 @@ fi
 echo "Response received (${#RESPONSE_TEXT} chars)"
 echo "Provider diagnostics: provider=${LLM_PROVIDER} model=${LLM_MODEL} transport=${PROVIDER_TRANSPORT:-n/a} http_status=${PROVIDER_HTTP_STATUS:-n/a} auth_header_kind=${PROVIDER_AUTH_HEADER_KIND:-n/a} exit_code=${PROVIDER_EXIT_CODE:-0} attempts=${PROVIDER_ATTEMPTS:-0} duration_seconds=${PROVIDER_DURATION_SECONDS:-0} stdout_bytes=${PROVIDER_STDOUT_BYTES:-0} stderr_bytes=${PROVIDER_STDERR_BYTES:-0} base_url_configured=${PROVIDER_BASE_URL_CONFIGURED:-false} api_url_configured=${PROVIDER_API_URL_CONFIGURED:-false}"
 
+write_review_parse_error() {
+  local reason="$1"
+  if [ -n "${API_RESPONSE_FILE:-}" ] && [ -f "${API_RESPONSE_FILE:-}" ]; then
+    write_provider_error_result "$reason" 0 "${PROVIDER_DURATION_SECONDS:-0}" "$API_RESPONSE_FILE" "${API_ERR_FILE:-/dev/null}"
+  else
+    echo "::error::${reason} — fail closed"
+    write_error_result "$reason"
+  fi
+}
+
 # Extract JSON from response
 REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/^{/,/^}/p' || true)
 if [ -z "$REVIEW_JSON" ]; then
@@ -655,20 +665,31 @@ fi
 # Validate JSON and extract verdict
 VERDICT="ESCALATE"
 PASSED=true
-if echo "$REVIEW_JSON" | jq . >/dev/null 2>&1; then
-  VERDICT=$(echo "$REVIEW_JSON" | jq -r '.verdict // "ESCALATE"')
-  SUMMARY=$(echo "$REVIEW_JSON" | jq -r '.summary // "No summary"')
-  echo "LLM verdict: $VERDICT"
-  echo "Summary: $SUMMARY"
-  echo "$REVIEW_JSON" | jq -r '.checks // {} | to_entries[] | "  \(.key): \(.value.verdict) (confidence: \(.value.confidence // "N/A"))"' 2>/dev/null || true
-
-  if [ "$VERDICT" = "FAIL" ] || [ "$VERDICT" = "ESCALATE" ]; then
-    PASSED=false
-  fi
-else
-  echo "::error::Could not parse LLM JSON — fail closed"
-  write_error_result "Could not parse LLM JSON"
+if [ -z "$(printf '%s' "$REVIEW_JSON" | tr -d '[:space:]')" ]; then
+  write_review_parse_error "Could not extract LLM review JSON"
   exit 1
+fi
+if ! printf '%s\n' "$REVIEW_JSON" | jq -e 'type == "object" and length > 0' >/dev/null 2>&1; then
+  write_review_parse_error "Could not parse LLM JSON"
+  exit 1
+fi
+VERDICT=$(printf '%s\n' "$REVIEW_JSON" | jq -r '.verdict // ""')
+case "$VERDICT" in
+  PASS|FAIL|ESCALATE)
+    ;;
+  *)
+    write_review_parse_error "LLM review verdict missing or invalid"
+    exit 1
+    ;;
+esac
+REVIEW_DETAIL_JSON=$(printf '%s\n' "$REVIEW_JSON" | jq .)
+SUMMARY=$(printf '%s\n' "$REVIEW_JSON" | jq -r '.summary // "No summary"')
+echo "LLM verdict: $VERDICT"
+echo "Summary: $SUMMARY"
+printf '%s\n' "$REVIEW_JSON" | jq -r '.checks // {} | to_entries[] | "  \(.key): \(.value.verdict) (confidence: \(.value.confidence // "N/A"))"' 2>/dev/null || true
+
+if [ "$VERDICT" = "FAIL" ] || [ "$VERDICT" = "ESCALATE" ]; then
+  PASSED=false
 fi
 
 # --- Write result ---
@@ -695,7 +716,7 @@ cat > "$RESULT_FILE" <<EOF
   "confidence_threshold": $CONFIDENCE_THRESHOLD,
   "response_length": ${#RESPONSE_TEXT},
   "diff_truncated": $TRUNCATED,
-  "review_detail": $(echo "$REVIEW_JSON" | jq . 2>/dev/null || echo "{}"),
+  "review_detail": $REVIEW_DETAIL_JSON,
   "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF

--- a/tests/test-github-language-gate-workflow.sh
+++ b/tests/test-github-language-gate-workflow.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/github-language-gate.yml"
+MATRIX="$ROOT_DIR/matrix/sentinel-matrix.yaml"
+SELF_TEST="$ROOT_DIR/.github/workflows/self-test.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1" needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file must contain: $needle"
+}
+
+assert_file_not_contains() {
+  local file="$1" needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file must not contain: $needle"
+  fi
+}
+
+[ -f "$WORKFLOW" ] || fail "GitHub language gate reusable workflow is missing"
+
+assert_file_contains "$WORKFLOW" "name: GitHub Language Gate"
+assert_file_contains "$WORKFLOW" "workflow_call:"
+assert_file_contains "$WORKFLOW" "enforcement_mode:"
+assert_file_contains "$WORKFLOW" "default: audit"
+assert_file_contains "$WORKFLOW" "report_comment:"
+assert_file_contains "$WORKFLOW" "default: false"
+assert_file_contains "$WORKFLOW" "repository: huanlongAI/sentinel-shared"
+assert_file_contains "$WORKFLOW" "path: .sentinel-shared"
+assert_file_contains "$WORKFLOW" "scripts/check-github-language-gate.py"
+assert_file_contains "$WORKFLOW" "--enforcement-mode"
+assert_file_contains "$WORKFLOW" "--github-output"
+assert_file_contains "$WORKFLOW" "中文门禁未通过"
+assert_file_contains "$WORKFLOW" "gh issue comment"
+assert_file_contains "$WORKFLOW" "inputs.report_comment"
+assert_file_not_contains "$WORKFLOW" "permissions:"
+
+assert_file_contains "$MATRIX" "GPC-008"
+assert_file_contains "$MATRIX" "GitHub 对外回复语言门禁"
+assert_file_contains "$MATRIX" "precheck_id: D-11"
+assert_file_contains "$MATRIX" "D-11:"
+assert_file_contains "$MATRIX" "check-github-language-gate.py"
+assert_file_contains "$MATRIX" "check_ids: [GPC-008]"
+
+assert_file_contains "$SELF_TEST" "python3 tests/test-github-language-gate.py"
+assert_file_contains "$SELF_TEST" "bash tests/test-github-language-gate-workflow.sh"
+
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$WORKFLOW"
+
+echo "github language gate workflow test passed"

--- a/tests/test-github-language-gate.py
+++ b/tests/test-github-language-gate.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-github-language-gate.py"
+
+
+def run_gate(event, enforcement_mode="enforce", github_output_path=None):
+    with tempfile.TemporaryDirectory() as tmp:
+        event_path = Path(tmp) / "event.json"
+        event_path.write_text(json.dumps(event, ensure_ascii=False), encoding="utf-8")
+        cmd = [
+            sys.executable,
+            str(SCRIPT),
+            "--event-path",
+            str(event_path),
+            "--enforcement-mode",
+            enforcement_mode,
+        ]
+        if github_output_path:
+            cmd.extend(["--github-output", str(github_output_path)])
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+
+class GitHubLanguageGateTests(unittest.TestCase):
+    def test_rejects_internal_pure_english_issue_title_and_body(self):
+        result = run_gate(
+            {
+                "action": "opened",
+                "issue": {
+                    "title": "[ledger test] Feishu delivery ledger summary",
+                    "body": "Purpose: verify Feishu delivery ledger summary.",
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/179",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["actor_scope"], "internal")
+        self.assertIn("title_missing_chinese", payload["errors"])
+        self.assertIn("body_missing_chinese", payload["errors"])
+
+    def test_accepts_chinese_issue_with_english_terms(self):
+        result = run_gate(
+            {
+                "action": "opened",
+                "issue": {
+                    "title": "[通知台账测试] Feishu delivery ledger summary",
+                    "body": "目的：验证 Feishu delivery ledger summary。",
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/180",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "passed")
+
+    def test_rejects_english_body_with_incidental_chinese_terms(self):
+        result = run_gate(
+            {
+                "action": "opened",
+                "issue": {
+                    "title": "[通知台账测试] Feishu delivery ledger summary",
+                    "body": (
+                        "Purpose: verify Feishu delivery ledger summary.\n\n"
+                        "Expected:\n"
+                        "- Issue opened goes to AI native工程通知.\n"
+                        "- Assigned goes DM-only to tongzhenghui.\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/181",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertIn("body_chinese_ratio_too_low", payload["errors"])
+
+    def test_external_contributor_violation_warns_without_failing(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": "Status: ready. Next: close after verification.",
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/179#issuecomment-1",
+                    "author_association": "FIRST_TIME_CONTRIBUTOR",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(payload["actor_scope"], "external")
+        self.assertIn("comment_missing_chinese", payload["warnings"])
+        self.assertEqual(payload["errors"], [])
+
+    def test_audit_mode_reports_internal_violation_without_failing(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": "Status: blocked pending runtime owner evidence.",
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/164#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            },
+            enforcement_mode="audit",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIn("comment_missing_chinese", payload["errors"])
+        self.assertTrue(payload["audit_mode"])
+
+    def test_allows_owner_confirmation_yaml_without_chinese(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "owner_confirmation_response_v1:\n"
+                        "  dispatch_id: FE-OC-001\n"
+                        "  decision: confirmed\n"
+                        "  blockers: []\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/101#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "passed")
+        self.assertTrue(payload["structured_yaml_allowed"])
+
+    def test_writes_github_output_for_failed_comment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            github_output_path = Path(tmp) / "github-output.txt"
+            result = run_gate(
+                {
+                    "action": "created",
+                    "issue": {
+                        "number": 164,
+                        "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/164",
+                    },
+                    "comment": {
+                        "body": "Status: blocked pending runtime owner evidence.",
+                        "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/164#issuecomment-1",
+                        "author_association": "MEMBER",
+                    },
+                },
+                github_output_path=github_output_path,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            github_output = github_output_path.read_text(encoding="utf-8")
+            self.assertIn("status=failed", github_output)
+            self.assertIn("target_issue_number=164", github_output)
+            self.assertIn("errors=comment_missing_chinese", github_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -155,6 +155,9 @@ case "${FAKE_CURL_MODE}" in
   empty)
     write_response 200 ''
     ;;
+  non_json_text)
+    write_response 200 '{"content":[{"type":"text","text":"No blocking findings."}]}'
+    ;;
   http_500)
     write_response 500 '{"error":{"message":"upstream unavailable"}}'
     ;;
@@ -507,6 +510,45 @@ test_heiyucode_provider_empty_output_fails_closed_with_diagnostics() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Empty output diagnostics mismatch"
 }
 
+test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json() {
+  local tmp fake_bin calls status
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  set +e
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="non_json_text" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+  status="$?"
+  set -e
+
+  [ "$status" -ne 0 ] || fail "Non-JSON review text should fail closed"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
+    and .status == "error"
+    and .error_type == "provider_error"
+    and .reason == "Could not extract LLM review JSON"
+    and .passed == false
+    and .escalate == true
+    and .http_status == "200"
+    and .stdout_bytes > 0
+    and (.response_tail | contains("No blocking findings."))
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Non-JSON review diagnostics mismatch"
+}
+
 test_heiyucode_provider_http_error_fails_closed_with_response_tail() {
   local tmp fake_bin calls status
   tmp="$(mktemp -d)"
@@ -749,6 +791,7 @@ test_heiyucode_provider_hard_fails_explicit_escalate_verdict
 test_heiyucode_provider_timeout_fails_closed_without_waiting_for_job_timeout
 test_heiyucode_provider_nonzero_exit_fails_closed_with_diagnostics
 test_heiyucode_provider_empty_output_fails_closed_with_diagnostics
+test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json
 test_heiyucode_provider_http_error_fails_closed_with_response_tail
 test_heiyucode_provider_retries_retryable_524_once
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure

--- a/tests/test-self-test-workflow.sh
+++ b/tests/test-self-test-workflow.sh
@@ -42,6 +42,8 @@ assert_file_contains "$WORKFLOW" "bash tests/test-aux-llm-workflows.sh"
 assert_file_contains "$WORKFLOW" "bash tests/test-owner-reviewed-override.sh"
 assert_file_contains "$WORKFLOW" "bash tests/test-review-gate-audit.sh"
 assert_file_contains "$WORKFLOW" "bash tests/test-agent-governance.sh"
+assert_file_contains "$WORKFLOW" "python3 tests/test-github-language-gate.py"
+assert_file_contains "$WORKFLOW" "bash tests/test-github-language-gate-workflow.sh"
 assert_file_contains "$WORKFLOW" "bash tests/test-self-test-workflow.sh"
 assert_file_contains "$WORKFLOW" "bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh"
 


### PR DESCRIPTION
## 摘要
- 新增 GitHub Language Gate reusable workflow，覆盖 issue / issue_comment 的中文语言策略。
- 新增 GPC-008 / D-11 sentinel matrix 映射、检测脚本和自测。
- 外部贡献者采用 warn，不在 Phase 1 阻断。

## 验证
- python3 tests/test-github-language-gate.py
- bash tests/test-github-language-gate-workflow.sh
- bash tests/test-self-test-workflow.sh
- ruby workflow YAML parse

## 合入顺序
本 PR 需要先于各 caller 仓合入，因为 caller workflow 引用 huanlongAI/sentinel-shared@main。