### PR TITLE
fix(llm-review): extract referenced RULINGS sections

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -127,6 +127,62 @@ file_size_bytes() {
   fi
 }
 
+referenced_ruling_ids_from_diff() {
+  printf '%s\n' "$DIFF_CONTENT" | { grep -Eo 'R-[0-9]{4}' || true; } | sort -u
+}
+
+is_rulings_anchor_file() {
+  local file="$1"
+  [ "$(basename "$file")" = "RULINGS.md" ]
+}
+
+extract_single_ruling_section() {
+  local file="$1" ruling_id="$2"
+  awk -v ruling_id="$ruling_id" '
+    $0 ~ "^###[[:space:]]+" ruling_id "([^0-9]|$)" {
+      in_section=1
+    }
+    in_section && $0 ~ "^###[[:space:]]+R-[0-9]{4}" && $0 !~ "^###[[:space:]]+" ruling_id "([^0-9]|$)" {
+      exit
+    }
+    in_section {
+      print
+    }
+  ' "$file" 2>/dev/null || true
+}
+
+extract_referenced_rulings_context() {
+  local file="$1" ids="$2"
+  local max_chars="${RULINGS_EXCERPT_MAX_CHARS:-50000}"
+  local context="" id section proposed
+
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    section="$(extract_single_ruling_section "$file" "$id")"
+    [ -z "$section" ] && continue
+
+    proposed="${context}
+--- ${file}#${id} ---
+${section}
+"
+    if [ "${#proposed}" -gt "$max_chars" ]; then
+      if [ -z "$context" ]; then
+        context="${proposed:0:$max_chars}
+...[TRUNCATED rulings excerpt at ${max_chars} chars]
+"
+      else
+        context="${context}
+...[TRUNCATED rulings excerpt before ${id}; max ${max_chars} chars]
+"
+      fi
+      break
+    fi
+    context="$proposed"
+  done <<< "$ids"
+
+  printf '%s' "$context"
+}
+
 safe_stderr_tail() {
   local file="$1"
   if [ ! -s "$file" ]; then
@@ -388,6 +444,16 @@ if [ -n "$ANCHOR_KV" ]; then
 $(cat "$file_path")
 "
         echo "  Loaded: $file_path (${FILE_SIZE}B)"
+      elif is_rulings_anchor_file "$file_path"; then
+        RULING_IDS="$(referenced_ruling_ids_from_diff)"
+        RULINGS_CONTEXT="$(extract_referenced_rulings_context "$file_path" "$RULING_IDS")"
+        if [ -n "$RULINGS_CONTEXT" ]; then
+          CONTEXT_PACK="${CONTEXT_PACK}
+${RULINGS_CONTEXT}"
+          echo "  Extracted: $file_path refs=[$(printf '%s' "$RULING_IDS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')] from large anchor (${FILE_SIZE}B)"
+        else
+          echo "  Skipped: $file_path (too large: ${FILE_SIZE}B; no referenced Ruling sections found)"
+        fi
       else
         echo "  Skipped: $file_path (too large: ${FILE_SIZE}B)"
       fi

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -733,6 +733,74 @@ SH
     "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Large prompt result metadata mismatch"
 }
 
+test_large_rulings_anchor_extracts_referenced_ruling_sections() {
+  local tmp fake_bin calls prompt
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat >> "$tmp/repo/.sentinel/config.yaml" <<'YAML'
+anchor_files:
+  rulings: "RULINGS.md"
+YAML
+  {
+    printf 'RULINGS HEADER\n'
+    head -c 62000 /dev/zero | tr '\0' 'x'
+    printf '\n\n### R-0123｜NODE-D Test Ruling\n\n'
+    printf 'R-0123 source excerpt required for GPC-003.\n'
+    printf 'This exact R-0123 line must be loaded from the large RULINGS.md anchor.\n\n'
+    printf '### R-0124｜Unreferenced Ruling\n\n'
+    printf 'This unreferenced R-0124 line should not be loaded.\n'
+  } > "$tmp/repo/RULINGS.md"
+  git -C "$tmp/repo" add .sentinel/config.yaml RULINGS.md
+  git -C "$tmp/repo" commit -q -m "add large rulings"
+
+  cat > "$tmp/repo/contract.json" <<'JSON'
+{"ref":"RULINGS.md#R-0123","status":"request_only"}
+JSON
+  git -C "$tmp/repo" add contract.json
+  git -C "$tmp/repo" commit -q -m "reference ruling"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-binary)
+      body="${2#@}"
+      cp "$body" "$FAKE_CALL_DIR/request.json"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat <<'JSON'
+{"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.95,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  prompt="$(jq -r '.messages[0].content' "$calls/request.json")"
+  assert_contains "$prompt" "R-0123 source excerpt required for GPC-003."
+  assert_contains "$prompt" "This exact R-0123 line must be loaded from the large RULINGS.md anchor."
+  if [[ "$prompt" == *"This unreferenced R-0124 line should not be loaded."* ]]; then
+    fail "Unreferenced RULINGS section should not be loaded into the LLM context pack"
+  fi
+}
+
 test_aggregate_includes_llm_review_failure() {
   local tmp output code
   tmp="$(mktemp -d)"
@@ -783,6 +851,7 @@ test_workflow_requires_llm_result_when_llm_enabled() {
 test_anthropic_provider_uses_messages_api
 test_request_body_uses_file_backed_payload_for_anthropic
 test_large_prompt_uses_file_backed_payload_without_arg_list_overflow
+test_large_rulings_anchor_extracts_referenced_ruling_sections
 test_heiyucode_provider_uses_messages_api
 test_heiyucode_provider_hard_fails_explicit_fail_verdict
 test_anthropic_api_error_fails_closed


### PR DESCRIPTION
## 变更

修复 Consistency Sentinel LLM review 在治理仓库中遇到大号 `RULINGS.md` anchor 时的 GPC-003 上下文缺失问题。

当前逻辑会因为 `RULINGS.md` 超过 50KB 而整文件跳过，导致 LLM 对 `R-0123` / `R-0130` / `R-0132` 等明确引用无法做原文级比对。本 PR 改为：当大号 anchor 是 `RULINGS.md` 时，从 PR diff 中提取 `R-xxxx` 引用，只加载对应 Ruling 段落原文。

## 边界

- 不加载整个 `RULINGS.md`
- 不改变 LLM verdict / fail-closed 规则
- 不改变 owner-reviewed override 机制
- 不改变 reusable workflow 权限模型
- 不改 tzhOS P0Q 合同包内容

## 验证

- RED: 新增回归测试在旧实现下失败，原因是大号 `RULINGS.md` 被跳过
- GREEN: `bash tests/test-llm-review-provider-router.sh` PASS
- `bash tests/test-policy-file.sh` PASS
- `bash tests/test-self-test-workflow.sh` PASS
- `bash tests/test-cascade-workflow.sh` PASS
- `bash tests/test-agent-governance.sh` PASS
- `git diff --check HEAD~1..HEAD` PASS
- 本地 #452 P0Q request 仿真：成功抽取 `R-0123` / `R-0130` / `R-0132`，未抽取相邻 `R-0124` / `R-0131`

## Follow-up

合并本 PR 后，需要 rerun tzhOS PR #452 的 `sentinel / 一致性检查`。
