### PR TITLE
sentinel: add ai-output gate parity

### DIFF
--- a/.github/workflows/github-language-gate.yml
+++ b/.github/workflows/github-language-gate.yml
@@ -1,4 +1,4 @@
-name: GitHub Language Gate
+name: GitHub Issue / Comment Gate
 
 on:
   workflow_call:
@@ -25,7 +25,7 @@ jobs:
           path: .sentinel-shared
           token: ${{ github.token }}
 
-      - name: Check GitHub issue/comment Chinese language
+      - name: Check GitHub issue/comment language and AI output contract
         id: language_gate
         continue-on-error: true
         run: |
@@ -34,7 +34,7 @@ jobs:
             --enforcement-mode "${{ inputs.enforcement_mode }}" \
             --github-output "$GITHUB_OUTPUT"
 
-      - name: Report Chinese language gate violation
+      - name: Report GitHub issue/comment gate violation
         if: inputs.report_comment && steps.language_gate.outputs.status != 'passed' && steps.language_gate.outputs.target_issue_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -45,7 +45,7 @@ jobs:
           ISSUE_NUMBER: ${{ steps.language_gate.outputs.target_issue_number }}
         run: |
           cat > "$RUNNER_TEMP/github-language-gate-comment.md" <<EOF
-          ## 中文门禁未通过
+          ## GitHub Issue / Comment 门禁未通过
 
           检测目标：$GATE_TARGET_URL
 
@@ -54,9 +54,11 @@ jobs:
           错误码：$GATE_ERRORS$GATE_WARNINGS
 
           请将 Issue（事项）标题、正文或评论补充简体中文说明后重新编辑。英文术语、命令、路径、字段名和日志可以保留，但不能提交纯英文内容。
+
+          如果评论使用 `<!-- ai-output:v1 -->`，请补齐类型、结论、依据、当前状态、下一步唯一动作、需要人处理、不确定项，并确保判断词带证据。
           EOF
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/github-language-gate-comment.md"
 
-      - name: Fail Chinese language gate
+      - name: Fail GitHub issue/comment gate
         if: steps.language_gate.outcome == 'failure'
         run: exit 1

--- a/scripts/check-github-language-gate.py
+++ b/scripts/check-github-language-gate.py
@@ -21,6 +21,44 @@ OWNER_CONFIRMATION_ROOTS = (
     "frontend_owner_confirmation:",
 )
 INTERNAL_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+AI_OUTPUT_MARKER = "<!-- ai-output:v1 -->"
+AI_OUTPUT_FIELD_RE = re.compile(r"^【([^】]+)】\s*(.*)$")
+AI_OUTPUT_REQUIRED_FIELDS = (
+    "类型",
+    "结论",
+    "依据",
+    "当前状态",
+    "下一步唯一动作",
+    "需要人处理",
+    "不确定项",
+)
+AI_OUTPUT_ALLOWED_TYPES = {
+    "status_update",
+    "gap_report",
+    "decision_request",
+    "acceptance_report",
+}
+AI_OUTPUT_EVIDENCE_TERMS = (
+    "已完成",
+    "已确认",
+    "已授权",
+    "已阻塞",
+    "已通过",
+    "可关闭",
+    "runtime ready",
+    "production ready",
+)
+AI_OUTPUT_EMPTY_EVIDENCE = {
+    "",
+    "无",
+    "none",
+    "n/a",
+    "na",
+    "no evidence",
+    "无证据",
+    "未提供",
+    "待补",
+}
 
 
 def has_chinese(text):
@@ -45,6 +83,69 @@ def chinese_signal_too_weak(text):
 def is_structured_owner_yaml(text):
     stripped = (text or "").lstrip()
     return any(stripped.startswith(root) for root in OWNER_CONFIRMATION_ROOTS)
+
+
+def parse_ai_output_fields(text):
+    fields = {}
+    current_key = None
+
+    for line in (text or "").splitlines():
+        match = AI_OUTPUT_FIELD_RE.match(line.strip())
+        if match:
+            current_key = match.group(1).strip()
+            fields[current_key] = match.group(2).strip()
+            continue
+
+        if current_key:
+            value = line.strip()
+            if value:
+                existing = fields.get(current_key, "")
+                fields[current_key] = f"{existing}\n{value}".strip()
+
+    return fields
+
+
+def ai_output_type(fields):
+    raw_type = fields.get("类型", "").strip().lower()
+    for allowed_type in AI_OUTPUT_ALLOWED_TYPES:
+        if allowed_type in raw_type:
+            return allowed_type
+    return ""
+
+
+def has_evidence_for_ai_output(fields):
+    evidence = fields.get("依据", "").strip()
+    normalized = evidence.lower()
+    if normalized in AI_OUTPUT_EMPTY_EVIDENCE:
+        return False
+
+    return bool(evidence)
+
+
+def validate_ai_output_contract(text):
+    if AI_OUTPUT_MARKER not in (text or ""):
+        return []
+
+    violations = []
+    fields = parse_ai_output_fields(text)
+
+    for required_field in AI_OUTPUT_REQUIRED_FIELDS:
+        if required_field not in fields:
+            violations.append(f"ai_output_missing_{required_field}")
+
+    output_type = ai_output_type(fields)
+    if not output_type:
+        violations.append("ai_output_invalid_type")
+
+    if "NEEDS_CONTEXT" in (text or "") and output_type != "gap_report":
+        violations.append("ai_output_needs_context_requires_gap_report")
+
+    normalized_text = (text or "").lower()
+    if any(term in normalized_text for term in AI_OUTPUT_EVIDENCE_TERMS):
+        if not has_evidence_for_ai_output(fields):
+            violations.append("ai_output_evidence_required")
+
+    return violations
 
 
 def actor_scope(event, target):
@@ -89,6 +190,7 @@ def validate_comment(comment):
         errors.append("comment_missing_chinese")
     elif not structured_yaml_allowed and chinese_signal_too_weak(body):
         errors.append("comment_chinese_ratio_too_low")
+    errors.extend(validate_ai_output_contract(body))
 
     return {
         "kind": "issue_comment",

--- a/tests/test-github-language-gate-workflow.sh
+++ b/tests/test-github-language-gate-workflow.sh
@@ -25,7 +25,7 @@ assert_file_not_contains() {
 
 [ -f "$WORKFLOW" ] || fail "GitHub language gate reusable workflow is missing"
 
-assert_file_contains "$WORKFLOW" "name: GitHub Language Gate"
+assert_file_contains "$WORKFLOW" "name: GitHub Issue / Comment Gate"
 assert_file_contains "$WORKFLOW" "workflow_call:"
 assert_file_contains "$WORKFLOW" "enforcement_mode:"
 assert_file_contains "$WORKFLOW" "default: audit"
@@ -36,7 +36,8 @@ assert_file_contains "$WORKFLOW" "path: .sentinel-shared"
 assert_file_contains "$WORKFLOW" "scripts/check-github-language-gate.py"
 assert_file_contains "$WORKFLOW" "--enforcement-mode"
 assert_file_contains "$WORKFLOW" "--github-output"
-assert_file_contains "$WORKFLOW" "中文门禁未通过"
+assert_file_contains "$WORKFLOW" "GitHub Issue / Comment 门禁未通过"
+assert_file_contains "$WORKFLOW" "ai-output:v1"
 assert_file_contains "$WORKFLOW" "gh issue comment"
 assert_file_contains "$WORKFLOW" "inputs.report_comment"
 assert_file_not_contains "$WORKFLOW" "permissions:"

--- a/tests/test-github-language-gate.py
+++ b/tests/test-github-language-gate.py
@@ -173,6 +173,130 @@ class GitHubLanguageGateTests(unittest.TestCase):
             self.assertIn("target_issue_number=164", github_output)
             self.assertIn("errors=comment_missing_chinese", github_output)
 
+    def test_accepts_valid_ai_output_contract_comment(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "<!-- ai-output:v1 -->\n"
+                        "【类型】status_update\n"
+                        "【结论】DS-1A sandbox pilot evidence accepted，未声明 production ready。\n"
+                        "【依据】PR #110；CI sentinel success；integration test evidence 已记录。\n"
+                        "【当前状态】accepted\n"
+                        "【下一步唯一动作】Package Owner 更新 Task Snapshot。\n"
+                        "【需要人处理】Package Owner\n"
+                        "【不确定项】无\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/200#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["status"], "passed")
+
+    def test_rejects_ai_output_missing_required_field(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "<!-- ai-output:v1 -->\n"
+                        "【类型】status_update\n"
+                        "【结论】已完成。\n"
+                        "【依据】PR #110\n"
+                        "【当前状态】accepted\n"
+                        "【下一步唯一动作】关闭。\n"
+                        "【需要人处理】Package Owner\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/200#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertIn("ai_output_missing_不确定项", payload["errors"])
+
+    def test_rejects_ai_output_invalid_type(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "<!-- ai-output:v1 -->\n"
+                        "【类型】普通同步\n"
+                        "【结论】继续推进整体治理。\n"
+                        "【依据】PR #110\n"
+                        "【当前状态】doing\n"
+                        "【下一步唯一动作】继续推进。\n"
+                        "【需要人处理】无\n"
+                        "【不确定项】无\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/200#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertIn("ai_output_invalid_type", payload["errors"])
+
+    def test_rejects_needs_context_without_gap_report(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "<!-- ai-output:v1 -->\n"
+                        "【类型】status_update\n"
+                        "【结论】NEEDS_CONTEXT：缺少 Task Snapshot。\n"
+                        "【依据】未找到 task-snapshot:v1\n"
+                        "【当前状态】blocked\n"
+                        "【下一步唯一动作】补 Task Snapshot。\n"
+                        "【需要人处理】Package Owner\n"
+                        "【不确定项】当前 DRI\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/200#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertIn("ai_output_needs_context_requires_gap_report", payload["errors"])
+
+    def test_rejects_done_claim_without_evidence(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "<!-- ai-output:v1 -->\n"
+                        "【类型】status_update\n"
+                        "【结论】已完成，可以关闭。\n"
+                        "【依据】无\n"
+                        "【当前状态】done\n"
+                        "【下一步唯一动作】关闭 Issue。\n"
+                        "【需要人处理】无\n"
+                        "【不确定项】无\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/200#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertIn("ai_output_evidence_required", payload["errors"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds `ai-output:v1` contract validation to the shared GitHub issue/comment gate so caller repos can migrate without losing Delivery Recovery Mode guardrails.

## Why

`hl-dispatch#197` was closed because switching to the shared reusable workflow would have removed the local `ai-output:v1` lint added in `hl-dispatch#202`.

This PR brings `sentinel-shared` to parity:

- required `ai-output:v1` fields
- allowed public update classes
- `NEEDS_CONTEXT` requires `gap_report`
- evidence required for judgment words such as 已完成 / 已确认 / 可关闭 / runtime ready / production ready

## E Dual Audit

E1 delivery / evidence audit: PASS_WITH_CONDITIONS

- Preserve No Evidence, No Done.
- Preserve No Context, No AI Guess.
- Do not let shared workflow migration weaken hl-dispatch Delivery Recovery gates.

E2 automation / safety audit: PASS_WITH_CONDITIONS

- Keep reusable workflow permissions out of callee.
- Keep existing `workflow_call` contract.
- Extend script behavior and tests only.
- Do not change caller repos in this PR.

Conditions applied.

## What changed

- `scripts/check-github-language-gate.py`
  - validates `<!-- ai-output:v1 -->` comments when marker is present
  - adds required field, type, NEEDS_CONTEXT, and evidence checks
- `.github/workflows/github-language-gate.yml`
  - updates user-facing gate wording to mention AI output contract
- `tests/test-github-language-gate.py`
  - adds valid and invalid `ai-output:v1` cases
- `tests/test-github-language-gate-workflow.sh`
  - updates workflow shape assertions

## What did not change

- No caller repo changes.
- No workflow permissions added to reusable workflow.
- No Feishu/Bitable/Project behavior.
- No business code.
- No branch protection/ruleset changes.

## Tests run

```text
python3 -m py_compile scripts/check-github-language-gate.py tests/test-github-language-gate.py
python3 tests/test-github-language-gate.py
bash tests/test-github-language-gate-workflow.sh
ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
bash tests/test-self-test-workflow.sh
bash tests/test-caller-sync-workflow.sh
bash tests/test-aux-llm-workflows.sh
for t in tests/test-*.sh; do bash "$t"; done
git diff --check
```

Observed result: all completed successfully locally.

## Risk

Low/medium. Existing Chinese language gate behavior is preserved, but comments that explicitly include `<!-- ai-output:v1 -->` now receive extra structure checks.

## Rollback

Revert this PR to restore the shared gate to Chinese-language-only behavior.

## Follow-up

After this PR merges, create a fresh `hl-dispatch` migration PR from current `main` to replace local gate implementation with the shared reusable workflow.
