### PR TITLE
fix(sentinel): load three-digit RULINGS anchors

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -128,7 +128,7 @@ file_size_bytes() {
 }
 
 referenced_ruling_ids_from_diff() {
-  printf '%s\n' "$DIFF_CONTENT" | { grep -Eo 'R-[0-9]{4}' || true; } | sort -u
+  printf '%s\n' "$DIFF_CONTENT" | { grep -Eo 'R-[0-9]{3,}([.][A-Za-z0-9]+)?' || true; } | sort -u
 }
 
 is_rulings_anchor_file() {
@@ -139,10 +139,16 @@ is_rulings_anchor_file() {
 extract_single_ruling_section() {
   local file="$1" ruling_id="$2"
   awk -v ruling_id="$ruling_id" '
-    $0 ~ "^###[[:space:]]+" ruling_id "([^0-9]|$)" {
+    BEGIN {
+      escaped_ruling_id = ruling_id
+      gsub(/[.]/, "[.]", escaped_ruling_id)
+      heading_pattern = "^##+[[:space:]]+" escaped_ruling_id "([^0-9A-Za-z.]|$)"
+      next_ruling_pattern = "^##+[[:space:]]+R-[0-9][0-9][0-9][0-9]*([.][A-Za-z0-9]+)?([^0-9A-Za-z.]|$)"
+    }
+    $0 ~ heading_pattern {
       in_section=1
     }
-    in_section && $0 ~ "^###[[:space:]]+R-[0-9]{4}" && $0 !~ "^###[[:space:]]+" ruling_id "([^0-9]|$)" {
+    in_section && $0 ~ next_ruling_pattern && $0 !~ heading_pattern {
       exit
     }
     in_section {

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -801,6 +801,76 @@ SH
   fi
 }
 
+test_large_rulings_anchor_extracts_three_digit_ruling_sections() {
+  local tmp fake_bin calls prompt
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat >> "$tmp/repo/.sentinel/config.yaml" <<'YAML'
+anchor_files:
+  governance_rulings: "governance/RULINGS.md"
+YAML
+  mkdir -p "$tmp/repo/governance"
+  {
+    printf 'RULINGS HEADER\n'
+    head -c 62000 /dev/zero | tr '\0' 'x'
+    printf '\n\n## R-077 biz.sales.order PM Cap-Spec candidate-only Draft PR authorization readback\n\n'
+    printf 'R-077 source excerpt required for GPC-003.\n'
+    printf 'This exact R-077 line must be loaded from the large governance/RULINGS.md anchor.\n\n'
+    printf '## R-078 Unreferenced Ruling\n\n'
+    printf 'This unreferenced R-078 line should not be loaded.\n'
+  } > "$tmp/repo/governance/RULINGS.md"
+  git -C "$tmp/repo" add .sentinel/config.yaml governance/RULINGS.md
+  git -C "$tmp/repo" commit -q -m "add large governance rulings"
+
+  cat > "$tmp/repo/traceability.yaml" <<'YAML'
+source_rulings:
+  - governance/RULINGS.md#R-077
+YAML
+  git -C "$tmp/repo" add traceability.yaml
+  git -C "$tmp/repo" commit -q -m "reference R-077"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-binary)
+      body="${2#@}"
+      cp "$body" "$FAKE_CALL_DIR/request.json"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat <<'JSON'
+{"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.95,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  prompt="$(jq -r '.messages[0].content' "$calls/request.json")"
+  assert_contains "$prompt" "R-077 source excerpt required for GPC-003."
+  assert_contains "$prompt" "This exact R-077 line must be loaded from the large governance/RULINGS.md anchor."
+  if [[ "$prompt" == *"This unreferenced R-078 line should not be loaded."* ]]; then
+    fail "Unreferenced three-digit RULINGS section should not be loaded into the LLM context pack"
+  fi
+}
+
 test_aggregate_includes_llm_review_failure() {
   local tmp output code
   tmp="$(mktemp -d)"
@@ -852,6 +922,7 @@ test_anthropic_provider_uses_messages_api
 test_request_body_uses_file_backed_payload_for_anthropic
 test_large_prompt_uses_file_backed_payload_without_arg_list_overflow
 test_large_rulings_anchor_extracts_referenced_ruling_sections
+test_large_rulings_anchor_extracts_three_digit_ruling_sections
 test_heiyucode_provider_uses_messages_api
 test_heiyucode_provider_hard_fails_explicit_fail_verdict
 test_anthropic_api_error_fails_closed


### PR DESCRIPTION
## Why

`hl-contracts` can reference governance rulings such as `R-077` from `governance/RULINGS.md`. The sentinel LLM context loader only extracted four-digit `R-0123` style IDs and only matched `###` headings, so a valid `## R-077` ruling anchor could be omitted from the LLM prompt even when it exists on base.

This caused the deterministic sentinel layers to pass while the LLM layer could still falsely report missing RULINGS evidence.

## What changed

- Allow referenced ruling IDs with three or more digits, including optional dotted suffixes.
- Extract RULINGS sections from `##` or deeper markdown headings.
- Add a regression test for a large `governance/RULINGS.md` anchor containing `## R-077`, verifying only the referenced section is loaded.

## What did not change

- No reusable workflow permission changes.
- No provider routing behavior changes.
- No caller repository configuration changes in this PR.
- No business contract or governance ruling content changes.

## Tests run

- `bash tests/test-llm-review-provider-router.sh`
- `git diff --check`

## Audit

- Attempted local GGP audit with `GGP_EXECUTOR=codex` on `scripts/llm-review.sh tests/test-llm-review-provider-router.sh`.
- The local runner did not return a fresh report after several minutes and was terminated; no GGP PASS is claimed. PR CI remains the merge gate for this tooling fix.

## Risk

- Low scoped tooling risk: this only expands which existing RULINGS sections are included in LLM context.
- Failure mode if incorrect: the LLM prompt may include the wrong RULINGS section or omit a required section; covered by existing `R-0123` and new `R-077` tests.

## Rollback

Revert this commit to restore the prior four-digit / `###`-only extraction behavior.
