### PR TITLE
[codex] fix sentinel large RULINGS anchor overview

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -189,6 +189,48 @@ ${section}
   printf '%s' "$context"
 }
 
+extract_rulings_overview_context() {
+  local file="$1"
+  local max_chars="${RULINGS_OVERVIEW_MAX_CHARS:-50000}"
+  local header_max_chars="${RULINGS_OVERVIEW_HEADER_MAX_CHARS:-4000}"
+  local header headings context
+
+  header="$(
+    awk '
+      /^##+[[:space:]]+R-[0-9][0-9][0-9][0-9]*([.][A-Za-z0-9]+)?([^0-9A-Za-z.]|$)/ { exit }
+      { print }
+    ' "$file" 2>/dev/null || true
+  )"
+  if [ "${#header}" -gt "$header_max_chars" ]; then
+    header="${header:0:$header_max_chars}
+...[TRUNCATED RULINGS prologue at ${header_max_chars} chars]"
+  fi
+
+  headings="$(
+    awk '
+      /^##+[[:space:]]+R-[0-9][0-9][0-9][0-9]*([.][A-Za-z0-9]+)?([^0-9A-Za-z.]|$)/ { print }
+    ' "$file" 2>/dev/null || true
+  )"
+
+  context="--- ${file} overview ---
+Large RULINGS anchor loaded as bounded overview because no direct R-id was found in the diff.
+This overview provides the RULINGS prologue and ruling heading index. It does not replace exact ruling excerpts; if a specific R-id is referenced, Sentinel loads that section body separately.
+
+## RULINGS prologue
+${header}
+
+## Ruling heading index
+${headings}
+"
+
+  if [ "${#context}" -gt "$max_chars" ]; then
+    context="${context:0:$max_chars}
+...[TRUNCATED RULINGS overview at ${max_chars} chars]"
+  fi
+
+  printf '%s' "$context"
+}
+
 safe_stderr_tail() {
   local file="$1"
   if [ ! -s "$file" ]; then
@@ -458,7 +500,14 @@ $(cat "$file_path")
 ${RULINGS_CONTEXT}"
           echo "  Extracted: $file_path refs=[$(printf '%s' "$RULING_IDS" | tr '\n' ' ' | sed 's/[[:space:]]*$//')] from large anchor (${FILE_SIZE}B)"
         else
-          echo "  Skipped: $file_path (too large: ${FILE_SIZE}B; no referenced Ruling sections found)"
+          RULINGS_CONTEXT="$(extract_rulings_overview_context "$file_path")"
+          if [ -n "$RULINGS_CONTEXT" ]; then
+            CONTEXT_PACK="${CONTEXT_PACK}
+${RULINGS_CONTEXT}"
+            echo "  Overview: $file_path no direct R-id refs; loaded bounded RULINGS overview (${FILE_SIZE}B)"
+          else
+            echo "  Skipped: $file_path (too large: ${FILE_SIZE}B; no referenced Ruling sections found)"
+          fi
         fi
       else
         echo "  Skipped: $file_path (too large: ${FILE_SIZE}B)"

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -871,6 +871,76 @@ SH
   fi
 }
 
+test_large_rulings_anchor_loads_overview_when_no_ruling_ids_are_referenced() {
+  local tmp fake_bin calls prompt
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+
+  cat >> "$tmp/repo/.sentinel/config.yaml" <<'YAML'
+anchor_files:
+  rulings: "RULINGS.md"
+YAML
+  {
+    printf '# RULINGS.md test register\n'
+    printf 'RULINGS root protocol must be visible even when no direct R-id appears in the diff.\n'
+    head -c 62000 /dev/zero | tr '\0' 'x'
+    printf '\n\n### R-0123｜Repo governance boundary\n\n'
+    printf 'R-0123 full body should not be loaded without a direct reference.\n\n'
+    printf '### R-0124｜Push authorization boundary\n\n'
+    printf 'R-0124 full body should not be loaded without a direct reference.\n'
+  } > "$tmp/repo/RULINGS.md"
+  git -C "$tmp/repo" add .sentinel/config.yaml RULINGS.md
+  git -C "$tmp/repo" commit -q -m "add large rulings"
+
+  cat > "$tmp/repo/repo-governance.md" <<'EOF'
+Repo sync governance packet without direct ruling id.
+EOF
+  git -C "$tmp/repo" add repo-governance.md
+  git -C "$tmp/repo" commit -q -m "add repo governance packet"
+
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-binary)
+      body="${2#@}"
+      cp "$body" "$FAKE_CALL_DIR/request.json"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cat <<'JSON'
+{"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.95,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}
+JSON
+SH
+  chmod +x "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      SENTINEL_LLM_PROVIDER="anthropic" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  prompt="$(jq -r '.messages[0].content' "$calls/request.json")"
+  assert_contains "$prompt" "--- RULINGS.md overview ---"
+  assert_contains "$prompt" "RULINGS root protocol must be visible even when no direct R-id appears in the diff."
+  assert_contains "$prompt" "### R-0123｜Repo governance boundary"
+  assert_contains "$prompt" "### R-0124｜Push authorization boundary"
+  if [[ "$prompt" == *"R-0123 full body should not be loaded without a direct reference."* ]]; then
+    fail "Large RULINGS overview should include headings, not full unreferenced ruling bodies"
+  fi
+}
+
 test_aggregate_includes_llm_review_failure() {
   local tmp output code
   tmp="$(mktemp -d)"
@@ -923,6 +993,7 @@ test_request_body_uses_file_backed_payload_for_anthropic
 test_large_prompt_uses_file_backed_payload_without_arg_list_overflow
 test_large_rulings_anchor_extracts_referenced_ruling_sections
 test_large_rulings_anchor_extracts_three_digit_ruling_sections
+test_large_rulings_anchor_loads_overview_when_no_ruling_ids_are_referenced
 test_heiyucode_provider_uses_messages_api
 test_heiyucode_provider_hard_fails_explicit_fail_verdict
 test_anthropic_api_error_fails_closed


### PR DESCRIPTION
## Summary
- Load a bounded RULINGS.md overview when a large RULINGS anchor has no direct R-id references in the diff.
- Keep the existing exact-section extraction path for directly referenced R-ids.
- Add regression coverage for large RULINGS anchors with no direct R-id in the diff.

## Root Cause
Large RULINGS.md anchors were skipped when no direct R-id appeared in the diff, so the LLM review layer could escalate because the ruling register context was absent.

## Verification
- bash -n scripts/llm-review.sh tests/test-llm-review-provider-router.sh && git diff --check
- bash tests/test-llm-review-provider-router.sh
- for test_script in tests/test-*.sh; do bash "$test_script"; done
- bash scripts/precheck-changelog.sh

## Non-effects
- No reusable workflow permissions changes.
- No branch protection, ruleset, CODEOWNERS, secrets, account, or seat changes.
- No force push.