### PR TITLE
fix(sentinel): recover malformed llm review json

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -774,6 +774,57 @@ write_review_parse_error() {
   fi
 }
 
+recover_malformed_review_json() {
+  local checks_file
+  checks_file="$(mktemp)"
+  printf '%s\n' "$LLM_CHECKS" > "$checks_file"
+  printf '%s\n' "$REVIEW_JSON" | python3 -c '
+import json
+import re
+import sys
+
+checks_path = sys.argv[1]
+text = sys.stdin.read()
+check_ids = [line.strip() for line in open(checks_path, encoding="utf-8") if line.strip()]
+
+verdict_values = re.findall(r"\"verdict\"\s*:\s*\"(PASS|FAIL|ESCALATE)\"", text)
+if not verdict_values:
+    sys.exit(1)
+
+top_verdict = verdict_values[0]
+effective_verdict = top_verdict
+if "FAIL" in verdict_values:
+    effective_verdict = "FAIL"
+elif "ESCALATE" in verdict_values:
+    effective_verdict = "ESCALATE"
+
+checks = {}
+for check_id in check_ids:
+    marker = f"\"{check_id}\""
+    idx = text.find(marker)
+    if idx < 0:
+        sys.exit(1)
+    window = text[idx:idx + 2000]
+    verdict_match = re.search(r"\"verdict\"\s*:\s*\"(PASS|FAIL|ESCALATE)\"", window)
+    if not verdict_match:
+        sys.exit(1)
+    confidence_match = re.search(r"\"confidence\"\s*:\s*([0-9]+(?:\.[0-9]+)?)", window)
+    confidence = float(confidence_match.group(1)) if confidence_match else None
+    checks[check_id] = {
+        "verdict": verdict_match.group(1),
+        "confidence": confidence,
+        "reason": "Recovered from malformed LLM JSON; original reason omitted because provider returned invalid JSON string escaping."
+    }
+
+print(json.dumps({
+    "verdict": effective_verdict,
+    "checks": checks,
+    "summary": "Recovered verdict from malformed LLM JSON; provider response contained JSON-like output with invalid string escaping."
+}, ensure_ascii=False))
+' "$checks_file"
+  rm -f "$checks_file"
+}
+
 # Extract JSON from response
 REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/^{/,/^}/p' || true)
 if [ -z "$REVIEW_JSON" ]; then
@@ -791,8 +842,14 @@ if [ -z "$(printf '%s' "$REVIEW_JSON" | tr -d '[:space:]')" ]; then
   exit 1
 fi
 if ! printf '%s\n' "$REVIEW_JSON" | jq -e 'type == "object" and length > 0' >/dev/null 2>&1; then
-  write_review_parse_error "Could not parse LLM JSON"
-  exit 1
+  RECOVERED_REVIEW_JSON="$(recover_malformed_review_json || true)"
+  if [ -z "$(printf '%s' "$RECOVERED_REVIEW_JSON" | tr -d '[:space:]')" ] \
+    || ! printf '%s\n' "$RECOVERED_REVIEW_JSON" | jq -e 'type == "object" and length > 0' >/dev/null 2>&1; then
+    write_review_parse_error "Could not parse LLM JSON"
+    exit 1
+  fi
+  echo "::warning::Recovered LLM review verdict from malformed JSON string escaping"
+  REVIEW_JSON="$RECOVERED_REVIEW_JSON"
 fi
 VERDICT=$(printf '%s\n' "$REVIEW_JSON" | jq -r '.verdict // ""')
 case "$VERDICT" in

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -135,6 +135,13 @@ write_response() {
   printf 'http_status=%s\ntime_total=0.01\nsize_download=%s\n' "$status" "$(wc -c < "$out" | tr -d ' ')"
 }
 
+write_text_response() {
+  local status="$1"
+  local text="$2"
+  jq -n --arg text "$text" '{content:[{type:"text",text:$text}]}' > "$out"
+  printf 'http_status=%s\ntime_total=0.01\nsize_download=%s\n' "$status" "$(wc -c < "$out" | tr -d ' ')"
+}
+
 case "${FAKE_CURL_MODE}" in
   pass)
     write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.96,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}'
@@ -157,6 +164,25 @@ case "${FAKE_CURL_MODE}" in
     ;;
   non_json_text)
     write_response 200 '{"content":[{"type":"text","text":"No blocking findings."}]}'
+    ;;
+  malformed_fenced_pass)
+    text=$(cat <<'EOF'
+```json
+{
+  "verdict": "PASS",
+  "checks": {
+    "GPC-003": {
+      "verdict": "PASS",
+      "confidence": 0.91,
+      "reason": "review copied a "quoted governance phrase" without escaping it"
+    }
+  },
+  "summary": "semantic pass"
+}
+```
+EOF
+)
+    write_text_response 200 "$text"
     ;;
   http_500)
     write_response 500 '{"error":{"message":"upstream unavailable"}}'
@@ -547,6 +573,37 @@ test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json() {
     and .stdout_bytes > 0
     and (.response_tail | contains("No blocking findings."))
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Non-JSON review diagnostics mismatch"
+}
+
+test_heiyucode_provider_recovers_malformed_fenced_pass_json() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="malformed_fenced_pass" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .status == "completed"
+    and .verdict == "PASS"
+    and .passed == true
+    and .review_detail.checks["GPC-003"].verdict == "PASS"
+    and (.review_detail.checks["GPC-003"].reason | contains("Recovered from malformed LLM JSON"))
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Malformed fenced PASS JSON should recover safely"
 }
 
 test_heiyucode_provider_http_error_fails_closed_with_response_tail() {
@@ -1003,6 +1060,7 @@ test_heiyucode_provider_timeout_fails_closed_without_waiting_for_job_timeout
 test_heiyucode_provider_nonzero_exit_fails_closed_with_diagnostics
 test_heiyucode_provider_empty_output_fails_closed_with_diagnostics
 test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json
+test_heiyucode_provider_recovers_malformed_fenced_pass_json
 test_heiyucode_provider_http_error_fails_closed_with_response_tail
 test_heiyucode_provider_retries_retryable_524_once
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure


### PR DESCRIPTION
## 变更

- 为 `scripts/llm-review.sh` 增加受限恢复路径：当 LLM 返回 JSON-like fenced block 但字符串转义非法时，提取枚举型 `verdict` 与各启用 check 的 `verdict` / `confidence`，生成可聚合的规范 JSON。
- 保持 fail-closed：普通非 JSON 文本仍失败；显式 `FAIL` / `ESCALATE` 仍失败；缺少启用 check verdict 时失败。
- 增加 provider-router 回归测试，覆盖 malformed fenced PASS JSON 恢复场景。

## 非影响

- 不修改 reusable workflow permissions。
- 不改变 `skip_llm` 默认值。
- 不改变 owner-reviewed override 逻辑。
- 不修改 branch protection / ruleset / caller repo 配置。

## 验证

- `git diff --check`
- `bash tests/test-llm-review-provider-router.sh`