### PR TITLE
[codex] Reject black-box AI output phrases in language gate

### DIFF
--- a/scripts/check-github-language-gate.py
+++ b/scripts/check-github-language-gate.py
@@ -48,6 +48,15 @@ AI_OUTPUT_EVIDENCE_TERMS = (
     "runtime ready",
     "production ready",
 )
+AI_OUTPUT_BLACK_BOX_PHRASES = (
+    "收到 / 已知 / 继续推进",
+    "继续推进整体治理",
+    "需要进一步确认",
+    "当前上下文显示",
+    "可能已经处理过",
+    "runtime 那个",
+    "hprd 已确认但无证据",
+)
 AI_OUTPUT_EMPTY_EVIDENCE = {
     "",
     "无",
@@ -144,6 +153,9 @@ def validate_ai_output_contract(text):
     if any(term in normalized_text for term in AI_OUTPUT_EVIDENCE_TERMS):
         if not has_evidence_for_ai_output(fields):
             violations.append("ai_output_evidence_required")
+
+    if any(phrase in normalized_text for phrase in AI_OUTPUT_BLACK_BOX_PHRASES):
+        violations.append("ai_output_black_box_phrase")
 
     return violations
 

--- a/tests/test-github-language-gate.py
+++ b/tests/test-github-language-gate.py
@@ -247,6 +247,31 @@ class GitHubLanguageGateTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertIn("ai_output_invalid_type", payload["errors"])
 
+    def test_rejects_black_box_phrase_even_with_valid_type_and_evidence(self):
+        result = run_gate(
+            {
+                "action": "created",
+                "comment": {
+                    "body": (
+                        "<!-- ai-output:v1 -->\n"
+                        "【类型】status_update\n"
+                        "【结论】继续推进整体治理。\n"
+                        "【依据】PR #110\n"
+                        "【当前状态】doing\n"
+                        "【下一步唯一动作】@xujiuming 在 PR #110 补 integration test。\n"
+                        "【需要人处理】@xujiuming\n"
+                        "【不确定项】无\n"
+                    ),
+                    "html_url": "https://github.com/huanlongAI/hl-dispatch/issues/200#issuecomment-1",
+                    "author_association": "MEMBER",
+                },
+            }
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertIn("ai_output_black_box_phrase", payload["errors"])
+
     def test_rejects_needs_context_without_gap_report(self):
         result = run_gate(
             {


### PR DESCRIPTION
## Summary

- Adds canonical black-box AI phrases to the shared GitHub language gate.
- Rejects `ai-output:v1` comments that use opaque progress language instead of evidence, owner, and next action.
- Adds a regression test proving valid output types still fail when they contain black-box phrasing.

## Non-Goals

- Does not change production runtime behavior.
- Does not authorize Delivery Recovery work by itself.
- Does not replace repository taskbooks, issues, PRs, or human audit.

## Validation

- `python3 tests/test-github-language-gate.py`
- `bash tests/test-github-language-gate-workflow.sh`
- `git diff --check`