### PR TITLE
fix: honor owner-reviewed Sentinel override

### DIFF
--- a/.github/workflows/consistency-sentinel.yml
+++ b/.github/workflows/consistency-sentinel.yml
@@ -105,6 +105,7 @@ jobs:
       # ---- LLM 一致性审查层 ----
       - name: "LLM: 语义一致性审查"
         if: always() && inputs.skip_llm != 'true'
+        continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           HEIYUCODE_AUTH_TOKEN: ${{ secrets.HEIYUCODE_AUTH_TOKEN }}


### PR DESCRIPTION
## 变更

- 给 reusable workflow 的 `LLM: 语义一致性审查` step 增加 `continue-on-error: true`。
- 保持 aggregate step 作为最终 gate 判定来源，使 `OWNER_REVIEWED_PASS` 能真正让 job 通过。

## 背景

tzhOS PR #517 中 owner-reviewed override 已被接受并聚合为 `OWNER_REVIEWED_PASS`，但 LLM step 先 exit 1 导致 GitHub check 仍失败。这与 sentinel-shared README 中 owner-reviewed override 的语义不一致。

## 验证

- `bash tests/test-owner-reviewed-override.sh`
- `bash tests/test-llm-review-provider-router.sh`
- `bash tests/test-self-test-workflow.sh`
- `git diff --check`
