### PR TITLE
[codex] Add PR doc readability sentinel check

### DIFF
--- a/.github/workflows/consistency-sentinel.yml
+++ b/.github/workflows/consistency-sentinel.yml
@@ -102,6 +102,21 @@ jobs:
         if: always() && hashFiles('.sentinel-shared/scripts/precheck-agent-governance.sh') != ''
         run: .sentinel-shared/scripts/precheck-agent-governance.sh
 
+      - name: "D-12: PR 文档中文可读性检查"
+        if: always() && hashFiles('.sentinel-shared/scripts/check-pr-doc-readability.py') != ''
+        run: |
+          set +e
+          python3 .sentinel-shared/scripts/check-pr-doc-readability.py \
+            --config .sentinel/config.yaml \
+            --results-dir "$SENTINEL_RESULTS_DIR" \
+            --summary-file "$SENTINEL_RESULTS_DIR/d12-pr-doc-readability-summary.md"
+          code=$?
+          set -e
+          if [ -f "$SENTINEL_RESULTS_DIR/d12-pr-doc-readability-summary.md" ]; then
+            cat "$SENTINEL_RESULTS_DIR/d12-pr-doc-readability-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$code"
+
       # ---- LLM 一致性审查层 ----
       - name: "LLM: 语义一致性审查"
         if: always() && inputs.skip_llm != 'true'
@@ -123,7 +138,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          REQUIRED_DETERMINISTIC_RESULTS="d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json d10-agent-governance.json"
+          REQUIRED_DETERMINISTIC_RESULTS="d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json d10-agent-governance.json d12-pr-doc-readability.json"
           REQUIRED_DETERMINISTIC_RESULT_FILES="$REQUIRED_DETERMINISTIC_RESULTS" .sentinel-shared/scripts/owner-reviewed-override.sh
 
       # ---- 判定聚合 ----
@@ -131,7 +146,7 @@ jobs:
         id: aggregate
         if: always()
         run: |
-          REQUIRED_RESULTS="d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json d10-agent-governance.json"
+          REQUIRED_RESULTS="d1-changelog.json d2-terminology.json d3-cascade.json d4-directory.json d5-capability-source.json d6-brand-token.json d10-agent-governance.json d12-pr-doc-readability.json"
           if [ "${{ inputs.skip_llm }}" != "true" ]; then
             REQUIRED_RESULTS="$REQUIRED_RESULTS llm-review.json"
           fi

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -53,6 +53,8 @@ jobs:
           bash tests/test-agent-governance.sh
           python3 tests/test-github-language-gate.py
           bash tests/test-github-language-gate-workflow.sh
+          python3 tests/test-pr-doc-readability.py
+          bash tests/test-pr-doc-readability-workflow.sh
           bash tests/test-self-test-workflow.sh
 
       - name: Check shell syntax

--- a/matrix/sentinel-matrix.yaml
+++ b/matrix/sentinel-matrix.yaml
@@ -130,6 +130,15 @@ dimensions:
         trigger: "GitHub Issue / issue_comment / gate-generated comment"
         phase: 1
 
+      - id: GPC-009
+        name: "PR 文档中文可读性"
+        severity: P1
+        method: deterministic
+        precheck_id: D-12
+        source: "Founder 2026-06-14 Dahuizi engineering-governance ruling"
+        trigger: "PR / push diff changes docs or deliverables Markdown"
+        phase: 1
+
   design_brand:
     id: DBC
     name: "设计与品牌一致性"
@@ -224,6 +233,10 @@ prechecks:
     script: check-github-language-gate.py
     check_ids: [GPC-008]
     description: "GitHub Issue / Comment 简体中文语言门禁"
+  D-12:
+    script: check-pr-doc-readability.py
+    check_ids: [GPC-009]
+    description: "PR 文档中文可读性检查"
 
 # LLM configuration
 llm:

--- a/scripts/aggregate.sh
+++ b/scripts/aggregate.sh
@@ -112,7 +112,14 @@ while IFS= read -r result_file; do
     fi
 
     # Extract issues
-    issues=$(jq -r '([.issues[]?, .violations[]?] + (if (.reason // "") != "" then [.reason] else [] end))[]?' "$result_file" 2>/dev/null || true)
+    issues=$(jq -r '
+      def issue_text:
+        if type == "string" then .
+        elif type == "object" then (.message // ((.path // "unknown") + ": " + (.code // "violation")))
+        else tostring
+        end;
+      (([.issues[]?, .violations[]?] | map(issue_text)) + (if (.reason // "") != "" then [.reason] else [] end))[]?
+    ' "$result_file" 2>/dev/null || true)
     while IFS= read -r issue; do
       [ -z "$issue" ] && continue
       ALL_ISSUES+=("[$check_id] $issue")
@@ -241,7 +248,14 @@ REPORT_FILE="$RESULTS_DIR/sentinel-report.md"
     r_name=$(jq -r '.check_name // (if (.review_id // "") == "llm-review" then "LLM Review" else "?" end)' "$result_file" 2>/dev/null || echo "?")
     r_pass=$(jq -r '.passed // false' "$result_file" 2>/dev/null || echo "false")
     r_verdict=$(jq -r '.verdict // ""' "$result_file" 2>/dev/null || echo "")
-    r_issues=$(jq -r '([.issues[]?, .violations[]?] + (if (.reason // "") != "" then [.reason] else [] end) | join("; ")) // ""' "$result_file" 2>/dev/null || echo "")
+    r_issues=$(jq -r '
+      def issue_text:
+        if type == "string" then .
+        elif type == "object" then (.message // ((.path // "unknown") + ": " + (.code // "violation")))
+        else tostring
+        end;
+      ((([.issues[]?, .violations[]?] | map(issue_text)) + (if (.reason // "") != "" then [.reason] else [] end)) | join("; ")) // ""
+    ' "$result_file" 2>/dev/null || echo "")
     if [ "$r_id" = "llm-review" ] \
       && [ "$r_pass" != "true" ] \
       && [ "$r_verdict" = "ESCALATE" ] \

--- a/scripts/check-pr-doc-readability.py
+++ b/scripts/check-pr-doc-readability.py
@@ -34,6 +34,16 @@ def run_git(args, cwd):
     return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
 
 
+def ref_points_at_head(ref, cwd):
+    ref_result = run_git(["rev-parse", "--verify", ref], cwd)
+    head_result = run_git(["rev-parse", "--verify", "HEAD"], cwd)
+    return (
+        ref_result.returncode == 0
+        and head_result.returncode == 0
+        and ref_result.stdout.strip() == head_result.stdout.strip()
+    )
+
+
 def repo_root():
     result = run_git(["rev-parse", "--show-toplevel"], Path.cwd())
     if result.returncode == 0:
@@ -228,23 +238,33 @@ def is_allowlisted(path, entries, today):
     return False, None
 
 
-def diff_args(cwd):
+def diff_arg_candidates(cwd):
     base_ref = os.environ.get("BASE_REF") or os.environ.get("GITHUB_BASE_REF")
+    candidates = []
     if base_ref:
-        return [f"origin/{base_ref}...HEAD"]
+        origin_ref = f"origin/{base_ref}"
+        if not ref_points_at_head(origin_ref, cwd):
+            candidates.append([f"{origin_ref}...HEAD"])
+        if not ref_points_at_head(base_ref, cwd):
+            candidates.append([f"{base_ref}...HEAD"])
     result = run_git(["rev-parse", "--verify", "HEAD~1"], cwd)
     if result.returncode == 0:
-        return ["HEAD~1", "HEAD"]
-    return ["--cached"]
+        candidates.append(["HEAD~1", "HEAD"])
+    candidates.append(["--cached"])
+    return candidates
 
 
 def changed_files(cwd):
-    args = diff_args(cwd)
-    name_status = run_git(["diff", "--name-status", "--diff-filter=ACMRT", *args], cwd)
-    numstat = run_git(["diff", "--numstat", "--diff-filter=ACMRT", *args], cwd)
+    name_status = None
+    numstat = None
+    for args in diff_arg_candidates(cwd):
+        name_status = run_git(["diff", "--name-status", "--diff-filter=ACMRT", *args], cwd)
+        numstat = run_git(["diff", "--numstat", "--diff-filter=ACMRT", *args], cwd)
+        if name_status.returncode == 0 and numstat.returncode == 0:
+            break
 
     files = {}
-    if name_status.returncode == 0:
+    if name_status and name_status.returncode == 0:
         for line in name_status.stdout.splitlines():
             parts = line.split("\t")
             if not parts:
@@ -253,7 +273,7 @@ def changed_files(cwd):
             path = parts[-1]
             files[path] = {"path": path, "status": status, "additions": 0}
 
-    if numstat.returncode == 0:
+    if numstat and numstat.returncode == 0:
         for line in numstat.stdout.splitlines():
             parts = line.split("\t")
             if len(parts) < 3:

--- a/scripts/check-pr-doc-readability.py
+++ b/scripts/check-pr-doc-readability.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+
+CJK_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]")
+ENGLISH_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+URL_RE = re.compile(r"https?://\S+")
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+DEFAULT_TARGET_PATTERNS = [
+    "docs/**/*.md",
+    "deliverables/**/*.md",
+    "README.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".github/copilot-instructions.md",
+]
+REQUIRED_SECTION_HEADINGS = ("中文摘要", "术语说明")
+ALLOWLIST_REQUIRED_FIELDS = ("path", "reason", "approval_ref", "expires_on")
+
+
+def run_git(args, cwd):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def repo_root():
+    result = run_git(["rev-parse", "--show-toplevel"], Path.cwd())
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def strip_quotes(value):
+    value = (value or "").strip()
+    if "#" in value:
+        value = value.split("#", 1)[0].strip()
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    return value
+
+
+def parse_bool(value, default=False):
+    value = str(value).strip().lower()
+    if value in {"true", "yes", "1", "on"}:
+        return True
+    if value in {"false", "no", "0", "off"}:
+        return False
+    return default
+
+
+def parse_float(value, default):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_doc_readability_config(config_path):
+    config = {
+        "mode": "disabled",
+        "target_patterns": DEFAULT_TARGET_PATTERNS,
+        "allowlist_file": "",
+        "min_cjk_ratio": 0.2,
+        "min_cjk_chars": 20,
+        "min_english_words": 80,
+        "min_changed_lines": 20,
+        "require_sections": True,
+    }
+    path = Path(config_path)
+    if not path.exists():
+        return config
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    in_section = False
+    current_list_key = None
+    section_values = {}
+    list_values = {}
+
+    for raw_line in lines:
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+
+        if indent == 0:
+            in_section = stripped.startswith("doc_readability:")
+            current_list_key = None
+            continue
+
+        if not in_section:
+            continue
+
+        if indent == 2 and re.match(r"^[A-Za-z_][A-Za-z0-9_-]*:", stripped):
+            key, value = stripped.split(":", 1)
+            key = key.strip()
+            value = strip_quotes(value)
+            if value:
+                section_values[key] = value
+                current_list_key = None
+            else:
+                list_values.setdefault(key, [])
+                current_list_key = key
+            continue
+
+        if indent >= 4 and current_list_key and stripped.startswith("- "):
+            list_values.setdefault(current_list_key, []).append(strip_quotes(stripped[2:]))
+
+    if "mode" in section_values:
+        config["mode"] = section_values["mode"].lower()
+    if "allowlist_file" in section_values:
+        config["allowlist_file"] = section_values["allowlist_file"]
+    if "min_cjk_ratio" in section_values:
+        config["min_cjk_ratio"] = parse_float(section_values["min_cjk_ratio"], config["min_cjk_ratio"])
+    if "min_cjk_chars" in section_values:
+        config["min_cjk_chars"] = parse_int(section_values["min_cjk_chars"], config["min_cjk_chars"])
+    if "min_english_words" in section_values:
+        config["min_english_words"] = parse_int(
+            section_values["min_english_words"], config["min_english_words"]
+        )
+    if "min_changed_lines" in section_values:
+        config["min_changed_lines"] = parse_int(
+            section_values["min_changed_lines"], config["min_changed_lines"]
+        )
+    if "require_sections" in section_values:
+        config["require_sections"] = parse_bool(section_values["require_sections"], True)
+    if list_values.get("target_patterns"):
+        config["target_patterns"] = list_values["target_patterns"]
+
+    if config["mode"] not in {"disabled", "audit", "enforce"}:
+        config["mode"] = "disabled"
+    return config
+
+
+def parse_allowlist_file(path):
+    entries = []
+    warnings = []
+    allowlist_path = Path(path)
+    if not path:
+        return entries, warnings
+    if not allowlist_path.exists():
+        warnings.append(
+            {
+                "code": "allowlist_file_missing",
+                "path": str(allowlist_path),
+                "message": f"allowlist file not found: {allowlist_path}",
+            }
+        )
+        return entries, warnings
+
+    current = None
+    for raw_line in allowlist_path.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#") or stripped == "allowlist:":
+            continue
+        if stripped.startswith("- "):
+            if current is not None:
+                entries.append(current)
+            current = {}
+            item = stripped[2:].strip()
+            if ":" in item:
+                key, value = item.split(":", 1)
+                current[key.strip()] = strip_quotes(value)
+            continue
+        if current is not None and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = strip_quotes(value)
+    if current is not None:
+        entries.append(current)
+
+    valid_entries = []
+    for entry in entries:
+        missing = [field for field in ALLOWLIST_REQUIRED_FIELDS if not entry.get(field)]
+        if missing:
+            warnings.append(
+                {
+                    "code": "allowlist_entry_invalid",
+                    "path": entry.get("path", ""),
+                    "message": f"allowlist entry missing fields: {', '.join(missing)}",
+                }
+            )
+            continue
+        valid_entries.append(entry)
+    return valid_entries, warnings
+
+
+def is_allowlisted(path, entries, today):
+    for entry in entries:
+        if entry.get("path") != path:
+            continue
+        try:
+            expires_on = date.fromisoformat(entry.get("expires_on", ""))
+        except ValueError:
+            return False, {
+                "code": "allowlist_entry_invalid_date",
+                "path": path,
+                "message": f"allowlist expires_on is invalid for {path}",
+            }
+        if expires_on < today:
+            return False, None
+        return True, {
+            "code": "doc_readability_allowlisted",
+            "path": path,
+            "approval_ref": entry["approval_ref"],
+            "expires_on": entry["expires_on"],
+            "message": f"{path} is temporarily allowlisted until {entry['expires_on']}",
+        }
+    return False, None
+
+
+def diff_args(cwd):
+    base_ref = os.environ.get("BASE_REF") or os.environ.get("GITHUB_BASE_REF")
+    if base_ref:
+        return [f"origin/{base_ref}...HEAD"]
+    result = run_git(["rev-parse", "--verify", "HEAD~1"], cwd)
+    if result.returncode == 0:
+        return ["HEAD~1", "HEAD"]
+    return ["--cached"]
+
+
+def changed_files(cwd):
+    args = diff_args(cwd)
+    name_status = run_git(["diff", "--name-status", "--diff-filter=ACMRT", *args], cwd)
+    numstat = run_git(["diff", "--numstat", "--diff-filter=ACMRT", *args], cwd)
+
+    files = {}
+    if name_status.returncode == 0:
+        for line in name_status.stdout.splitlines():
+            parts = line.split("\t")
+            if not parts:
+                continue
+            status = parts[0]
+            path = parts[-1]
+            files[path] = {"path": path, "status": status, "additions": 0}
+
+    if numstat.returncode == 0:
+        for line in numstat.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) < 3:
+                continue
+            added, _deleted, path = parts[0], parts[1], parts[-1]
+            if path not in files:
+                continue
+            try:
+                files[path]["additions"] = int(added)
+            except ValueError:
+                files[path]["additions"] = 0
+
+    return list(files.values())
+
+
+def matches_target(path, patterns):
+    for pattern in patterns:
+        if pattern == "docs/**/*.md" and path.startswith("docs/") and path.endswith(".md"):
+            return True
+        if pattern == "deliverables/**/*.md" and path.startswith("deliverables/") and path.endswith(".md"):
+            return True
+        if fnmatch.fnmatch(path, pattern):
+            return True
+    return False
+
+
+def prose_text(markdown):
+    text = HTML_COMMENT_RE.sub(" ", markdown)
+    text = FENCED_CODE_BLOCK_RE.sub(" ", text)
+    text = URL_RE.sub(" ", text)
+    text = INLINE_CODE_RE.sub(" ", text)
+    prose_lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("|") and stripped.endswith("|"):
+            continue
+        prose_lines.append(line)
+    return "\n".join(prose_lines)
+
+
+def metric_for_file(path, changed, config, root):
+    text = (root / path).read_text(encoding="utf-8")
+    prose = prose_text(text)
+    cjk_chars = len(CJK_RE.findall(prose))
+    english_words = len(ENGLISH_WORD_RE.findall(prose))
+    denominator = cjk_chars + english_words
+    cjk_ratio = cjk_chars / denominator if denominator else 1.0
+    missing_sections = [
+        heading for heading in REQUIRED_SECTION_HEADINGS if heading not in text
+    ]
+    eligible = changed["status"].startswith(("A", "C")) or changed["additions"] >= config["min_changed_lines"]
+    return {
+        "path": path,
+        "status": changed["status"],
+        "additions": changed["additions"],
+        "eligible_for_enforcement": eligible,
+        "cjk_chars": cjk_chars,
+        "english_words": english_words,
+        "cjk_ratio": round(cjk_ratio, 4),
+        "missing_required_sections": missing_sections,
+    }
+
+
+def requires_sections(path):
+    return path.startswith("docs/") or path.startswith("deliverables/")
+
+
+def violations_for_metric(metric, config):
+    if not metric["eligible_for_enforcement"]:
+        return []
+
+    path = metric["path"]
+    violations = []
+    english_heavy = metric["english_words"] >= config["min_english_words"]
+
+    if english_heavy and metric["cjk_chars"] == 0:
+        violations.append(
+            {
+                "code": "doc_missing_chinese",
+                "path": path,
+                "message": f"{path} has no Chinese prose characters",
+            }
+        )
+    elif english_heavy and (
+        metric["cjk_chars"] < config["min_cjk_chars"]
+        or metric["cjk_ratio"] < config["min_cjk_ratio"]
+    ):
+        violations.append(
+            {
+                "code": "doc_chinese_ratio_too_low",
+                "path": path,
+                "message": f"{path} Chinese readability ratio is too low",
+            }
+        )
+
+    if config["require_sections"] and requires_sections(path):
+        if "中文摘要" in metric["missing_required_sections"]:
+            violations.append(
+                {
+                    "code": "doc_missing_chinese_summary",
+                    "path": path,
+                    "message": f"{path} is missing a 中文摘要 section",
+                }
+            )
+        if "术语说明" in metric["missing_required_sections"]:
+            violations.append(
+                {
+                    "code": "doc_missing_terminology_notes",
+                    "path": path,
+                    "message": f"{path} is missing a 术语说明 section",
+                }
+            )
+    return violations
+
+
+def result_payload(mode, skipped, scanned_files, metrics, violations, warnings, started_at):
+    passed = mode != "enforce" or not violations
+    return {
+        "check_id": "D-12",
+        "check_name": "PR Doc Chinese Readability",
+        "passed": passed,
+        "mode": mode,
+        "skipped": skipped,
+        "scanned_files": scanned_files,
+        "metrics": metrics,
+        "violations": violations,
+        "warnings": warnings,
+        "runtime_ms": int((time.time() - started_at) * 1000),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def write_summary(path, payload):
+    if not path:
+        return
+    summary = Path(path)
+    summary.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "## D-12 PR 文档中文可读性检查",
+        "",
+        f"- mode: `{payload['mode']}`",
+        f"- passed: `{str(payload['passed']).lower()}`",
+        f"- scanned files: `{len(payload['scanned_files'])}`",
+        f"- violations: `{len(payload['violations'])}`",
+        "",
+    ]
+    if payload["violations"]:
+        lines.extend(["| File | Code | Message |", "| --- | --- | --- |"])
+        for violation in payload["violations"]:
+            lines.append(
+                f"| `{violation.get('path', '')}` | `{violation.get('code', '')}` | {violation.get('message', '')} |"
+            )
+        lines.append("")
+    elif payload["skipped"]:
+        lines.append("No applicable Markdown files were scanned.")
+    else:
+        lines.append("No readability violations found.")
+    summary.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv=None):
+    started_at = time.time()
+    parser = argparse.ArgumentParser(description="Check PR Markdown Chinese readability")
+    parser.add_argument("--config", default=".sentinel/config.yaml")
+    parser.add_argument("--results-dir", default=".sentinel/results")
+    parser.add_argument("--mode", choices=("disabled", "audit", "enforce"))
+    parser.add_argument("--summary-file")
+    args = parser.parse_args(argv)
+
+    root = repo_root()
+    config = parse_doc_readability_config(args.config)
+    if args.mode:
+        config["mode"] = args.mode
+
+    results_dir = Path(args.results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    result_file = results_dir / "d12-pr-doc-readability.json"
+    summary_file = args.summary_file or os.environ.get("D12_STEP_SUMMARY_FILE", "")
+
+    if config["mode"] == "disabled":
+        payload = result_payload("disabled", True, [], [], [], [], started_at)
+        result_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        write_summary(summary_file, payload)
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    allowlist_ref = config["allowlist_file"]
+    allowlist_path = str((root / allowlist_ref).resolve()) if allowlist_ref else ""
+    allowlist_entries, warnings = parse_allowlist_file(allowlist_path)
+
+    metrics = []
+    violations = []
+    today = date.today()
+    changes = changed_files(root)
+    changed_paths = {changed["path"] for changed in changes}
+    if allowlist_ref and allowlist_ref in changed_paths:
+        for entry in allowlist_entries:
+            path = entry.get("path", "")
+            if path and path not in changed_paths and (root / path).is_file():
+                changes.append(
+                    {
+                        "path": path,
+                        "status": "M",
+                        "additions": config["min_changed_lines"],
+                    }
+                )
+                changed_paths.add(path)
+
+    for changed in changes:
+        path = changed["path"]
+        full_path = root / path
+        if not matches_target(path, config["target_patterns"]):
+            continue
+        if not full_path.exists() or not full_path.is_file():
+            continue
+        metric = metric_for_file(path, changed, config, root)
+        metrics.append(metric)
+        file_violations = violations_for_metric(metric, config)
+        if not file_violations:
+            continue
+        allowed, allowlist_warning = is_allowlisted(path, allowlist_entries, today)
+        if allowlist_warning:
+            warnings.append(allowlist_warning)
+        if allowed:
+            continue
+        violations.extend(file_violations)
+
+    scanned_files = [metric["path"] for metric in metrics]
+    payload = result_payload(
+        config["mode"],
+        not scanned_files,
+        scanned_files,
+        metrics,
+        violations,
+        warnings,
+        started_at,
+    )
+    result_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    write_summary(summary_file, payload)
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+
+    if config["mode"] == "enforce" and violations:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test-pr-doc-readability-workflow.sh
+++ b/tests/test-pr-doc-readability-workflow.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SENTINEL_WORKFLOW="$ROOT_DIR/.github/workflows/consistency-sentinel.yml"
+MATRIX="$ROOT_DIR/matrix/sentinel-matrix.yaml"
+SELF_TEST="$ROOT_DIR/.github/workflows/self-test.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local file="$1" needle="$2"
+  grep -Fq -- "$needle" "$file" || fail "$file must contain: $needle"
+}
+
+assert_file_not_contains() {
+  local file="$1" needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    fail "$file must not contain: $needle"
+  fi
+}
+
+[ -f "$ROOT_DIR/scripts/check-pr-doc-readability.py" ] || fail "D-12 script is missing"
+
+assert_file_contains "$SENTINEL_WORKFLOW" "D-12: PR 文档中文可读性检查"
+assert_file_contains "$SENTINEL_WORKFLOW" "check-pr-doc-readability.py"
+assert_file_contains "$SENTINEL_WORKFLOW" "d12-pr-doc-readability.json"
+assert_file_contains "$SENTINEL_WORKFLOW" "GITHUB_STEP_SUMMARY"
+assert_file_not_contains "$SENTINEL_WORKFLOW" "paths:"
+
+assert_file_contains "$MATRIX" "GPC-009"
+assert_file_contains "$MATRIX" "PR 文档中文可读性"
+assert_file_contains "$MATRIX" "precheck_id: D-12"
+assert_file_contains "$MATRIX" "D-12:"
+assert_file_contains "$MATRIX" "check-pr-doc-readability.py"
+assert_file_contains "$MATRIX" "check_ids: [GPC-009]"
+
+assert_file_contains "$SELF_TEST" "python3 tests/test-pr-doc-readability.py"
+assert_file_contains "$SELF_TEST" "bash tests/test-pr-doc-readability-workflow.sh"
+
+ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' "$SENTINEL_WORKFLOW"
+
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/results"
+cat > "$tmp/results/d12-pr-doc-readability.json" <<'JSON'
+{
+  "check_id": "D-12",
+  "check_name": "PR Doc Chinese Readability",
+  "passed": false,
+  "violations": [
+    {
+      "code": "doc_missing_chinese",
+      "path": "docs/example.md",
+      "message": "docs/example.md has no Chinese prose characters"
+    }
+  ]
+}
+JSON
+
+set +e
+aggregate_output=$(RESULTS_DIR="$tmp/results" REQUIRED_RESULT_FILES="d12-pr-doc-readability.json" "$ROOT_DIR/scripts/aggregate.sh" 2>&1)
+aggregate_code=$?
+set -e
+
+[ "$aggregate_code" -eq 1 ] || fail "aggregate should fail when D-12 has blocking violations: $aggregate_output"
+grep -Fq "docs/example.md has no Chinese prose characters" "$tmp/results/sentinel-report.md" \
+  || fail "aggregate report must render D-12 object violation messages"
+jq -e '.issues[] | contains("docs/example.md has no Chinese prose characters")' "$tmp/results/aggregate.json" >/dev/null \
+  || fail "aggregate issues must include D-12 object violation messages"
+
+echo "pr doc readability workflow test passed"

--- a/tests/test-pr-doc-readability.py
+++ b/tests/test-pr-doc-readability.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -45,7 +46,7 @@ def init_repo():
     return tmp, repo
 
 
-def run_gate(repo, mode=None):
+def run_gate(repo, mode=None, extra_env=None):
     results_dir = repo / ".sentinel" / "results"
     command = [
         sys.executable,
@@ -57,7 +58,10 @@ def run_gate(repo, mode=None):
     ]
     if mode:
         command.extend(["--mode", mode])
-    result = subprocess.run(command, cwd=repo, capture_output=True, text=True)
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(command, cwd=repo, env=env, capture_output=True, text=True)
     result_file = results_dir / "d12-pr-doc-readability.json"
     payload = json.loads(result_file.read_text(encoding="utf-8")) if result_file.exists() else None
     return result, payload
@@ -78,6 +82,36 @@ class PrDocReadabilityTests(unittest.TestCase):
         self.assertTrue(payload["passed"])
         self.assertTrue(payload["skipped"])
         self.assertEqual(payload["scanned_files"], [])
+
+    def test_falls_back_when_github_base_ref_is_unavailable(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        doc = repo / "docs" / "delivery-recovery" / "BASE_REF_FALLBACK.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            textwrap.dedent(
+                """\
+                # Base Ref Fallback
+
+                ## 中文摘要
+
+                这个文档验证 GitHub Actions 的 base ref 环境变量不会让临时仓库扫描空结果。
+
+                ## 术语说明
+
+                - base ref：目标基线分支，用于计算 PR diff。
+                """
+            )
+            * 10,
+            encoding="utf-8",
+        )
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "add fallback doc"], repo)
+
+        result, payload = run_gate(repo, extra_env={"GITHUB_BASE_REF": "main"})
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(str(doc.relative_to(repo)), payload["scanned_files"])
 
     def test_rejects_added_english_governance_doc_in_enforce_mode(self):
         tmp, repo = init_repo()

--- a/tests/test-pr-doc-readability.py
+++ b/tests/test-pr-doc-readability.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-pr-doc-readability.py"
+
+
+def run(command, cwd, check=True):
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(command)}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def init_repo():
+    tmp = tempfile.TemporaryDirectory()
+    repo = Path(tmp.name) / "repo"
+    repo.mkdir()
+    run(["git", "init", "-q"], repo)
+    run(["git", "config", "user.email", "sentinel-test@example.invalid"], repo)
+    run(["git", "config", "user.name", "Sentinel Test"], repo)
+    (repo / ".sentinel").mkdir()
+    (repo / ".sentinel" / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            sentinel_version: "1.0"
+            doc_readability:
+              mode: enforce
+            """
+        ),
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("# 基线\n", encoding="utf-8")
+    run(["git", "add", "."], repo)
+    run(["git", "commit", "-q", "-m", "base"], repo)
+    return tmp, repo
+
+
+def run_gate(repo, mode=None):
+    results_dir = repo / ".sentinel" / "results"
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "--config",
+        ".sentinel/config.yaml",
+        "--results-dir",
+        str(results_dir),
+    ]
+    if mode:
+        command.extend(["--mode", mode])
+    result = subprocess.run(command, cwd=repo, capture_output=True, text=True)
+    result_file = results_dir / "d12-pr-doc-readability.json"
+    payload = json.loads(result_file.read_text(encoding="utf-8")) if result_file.exists() else None
+    return result, payload
+
+
+class PrDocReadabilityTests(unittest.TestCase):
+    def test_skips_when_no_target_markdown_changed(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        (repo / "scripts").mkdir()
+        (repo / "scripts" / "tool.py").write_text("print('ok')\n", encoding="utf-8")
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "change code only"], repo)
+
+        result, payload = run_gate(repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["passed"])
+        self.assertTrue(payload["skipped"])
+        self.assertEqual(payload["scanned_files"], [])
+
+    def test_rejects_added_english_governance_doc_in_enforce_mode(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        doc = repo / "docs" / "delivery-recovery" / "HL_PROGRESS_GOVERNANCE_LOOP_v0.1.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            "# HL Progress Governance Loop\n\n"
+            + "\n".join(
+                [
+                    "This governance contract defines status, evidence, owner, blocker, and gate semantics for engineering progress.",
+                    "GitHub remains the source of truth while dashboards and reports are projections for scanning.",
+                    "The document intentionally describes authority boundaries, acceptance evidence, and decision ownership.",
+                ]
+                * 20
+            ),
+            encoding="utf-8",
+        )
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "add english governance doc"], repo)
+
+        result, payload = run_gate(repo)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["passed"])
+        self.assertFalse(payload["skipped"])
+        self.assertEqual(payload["mode"], "enforce")
+        self.assertIn(str(doc.relative_to(repo)), payload["scanned_files"])
+        codes = {v["code"] for v in payload["violations"]}
+        self.assertIn("doc_missing_chinese", codes)
+        self.assertIn("doc_missing_chinese_summary", codes)
+        self.assertIn("doc_missing_terminology_notes", codes)
+
+    def test_audit_mode_reports_violations_without_failing(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        doc = repo / "docs" / "delivery-recovery" / "ENGLISH_ONLY.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("This delivery recovery governance note is English only.\n" * 80, encoding="utf-8")
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "add audit doc"], repo)
+
+        result, payload = run_gate(repo, mode="audit")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["passed"])
+        self.assertEqual(payload["mode"], "audit")
+        self.assertGreater(len(payload["violations"]), 0)
+
+    def test_accepts_chinese_summary_and_terminology_notes(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        doc = repo / "deliverables" / "tasks" / "HL-PROGRESS-TASKBOOK.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            textwrap.dedent(
+                """\
+                # HL Progress Taskbook
+
+                ## 中文摘要
+
+                本文定义工程进度治理任务书，说明 GitHub SSOT、证据、负责人、阻塞项和门禁状态。
+                文档允许保留英文术语，但必须提供中文解释，方便 Founder、PM 和工程成员阅读。
+
+                ## 术语说明
+
+                - GitHub SSOT：GitHub 作为事实源，不以飞书或看板作为最终证据。
+                - gate：门禁，用于阻止缺少证据或缺少上下文的变更。
+
+                ## Details
+
+                The exporter may use JSON, Markdown, and dashboard projections for scanning.
+                """
+            )
+            * 12,
+            encoding="utf-8",
+        )
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "add readable taskbook"], repo)
+
+        result, payload = run_gate(repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["passed"])
+        self.assertEqual(payload["violations"], [])
+        self.assertEqual(payload["metrics"][0]["missing_required_sections"], [])
+
+    def test_ignores_code_blocks_urls_and_table_pipes_for_language_metrics(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        doc = repo / "docs" / "delivery-recovery" / "CODE_HEAVY.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            textwrap.dedent(
+                """\
+                # Code Heavy Doc
+
+                ## 中文摘要
+
+                这个文档用于记录命令样例，正文中文足够，代码块里的英文命令不应降低可读性判断。
+
+                ## 术语说明
+
+                - exporter：导出器，用于读取 GitHub 证据并生成投影。
+
+                ```yaml
+                schema: hl-progress-work-item:v0.1
+                source:
+                  system: github
+                  repo: owner/repo
+                  pr_urls:
+                    - https://github.com/huanlongAI/hl-dispatch/pull/236
+                ```
+
+                | field | meaning |
+                | --- | --- |
+                | owner | owner handle |
+                """
+            ),
+            encoding="utf-8",
+        )
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "add code heavy doc"], repo)
+
+        result, payload = run_gate(repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["passed"])
+        metric = payload["metrics"][0]
+        self.assertLess(metric["english_words"], 20)
+        self.assertEqual(payload["violations"], [])
+
+    def test_unexpired_allowlist_suppresses_violation_and_expired_allowlist_fails(self):
+        tmp, repo = init_repo()
+        self.addCleanup(tmp.cleanup)
+        doc = repo / "docs" / "delivery-recovery" / "TEMP_ENGLISH_DRAFT.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("Temporary English governance draft.\n" * 80, encoding="utf-8")
+        allowlist = repo / "docs" / "readability-allowlist.yml"
+        allowlist.write_text(
+            textwrap.dedent(
+                """\
+                allowlist:
+                  - path: docs/delivery-recovery/TEMP_ENGLISH_DRAFT.md
+                    reason: temporary imported draft before Chinese rewrite
+                    approval_ref: https://github.com/huanlongAI/hl-dispatch/issues/236
+                    expires_on: 2999-01-01
+                """
+            ),
+            encoding="utf-8",
+        )
+        with (repo / ".sentinel" / "config.yaml").open("a", encoding="utf-8") as config:
+            config.write("  allowlist_file: docs/readability-allowlist.yml\n")
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "add allowlisted draft"], repo)
+
+        result, payload = run_gate(repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(payload["passed"])
+        self.assertEqual(payload["violations"], [])
+        self.assertEqual(payload["warnings"][0]["code"], "doc_readability_allowlisted")
+
+        allowlist.write_text(
+            allowlist.read_text(encoding="utf-8").replace("2999-01-01", "2000-01-01"),
+            encoding="utf-8",
+        )
+        run(["git", "add", "."], repo)
+        run(["git", "commit", "-q", "-m", "expire allowlist"], repo)
+
+        result, payload = run_gate(repo)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertFalse(payload["passed"])
+        codes = {v["code"] for v in payload["violations"]}
+        self.assertIn("doc_missing_chinese", codes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add D-12 / GPC-009 PR document Chinese readability as a deterministic Sentinel subcheck.
- Keep the check config-driven with default disabled/audit semantics and no workflow-level paths filter.
- Add structured JSON output, Sentinel aggregation support, matrix mapping, workflow wiring, and focused tests.

## Validation
- Ran the full sentinel-shared local regression suite.
- Ran new D-12 unit and workflow tests.
- Ran shell syntax and workflow YAML parse checks.
- Ran git diff --check.

## Rollout
- This PR only adds the shared Sentinel capability.
- Repos opt in via .sentinel/config.yaml; hl-dispatch starts with audit mode in a separate PR.
