### PR TITLE
治理：同步仓库地图版本锚点

### DIFF
--- a/docs/agents-governance-map.md
+++ b/docs/agents-governance-map.md
@@ -1,10 +1,10 @@
 # HuanlongAI AGENTS Governance Map
 
 > Status: ACTIVE
-> Last updated: 2026-06-04
+> Last updated: 2026-06-17
 > Owner: NODE-M operational authority; AUM / tzhOS remain governance SSOT
 
-本文件是 `huanlongAI` 工作区的 Agent 入口治理地图，不是新的仓库清单真源，也不是新的规则真源。活跃仓库清单以 tzhOS `40-PPR/REPO-MAP.md@v1.4.12` 为 SSOT；规则真源仍是各 repo 的 `CLAUDE.md`、直接或目录继承的 `AGENTS.md`、tzhOS / AUM registry、仓库 CI gate 与当前任务契约。
+本文件是 `huanlongAI` 工作区的 Agent 入口治理地图，不是新的仓库清单真源，也不是新的规则真源。活跃仓库清单以 tzhOS `40-PPR/REPO-MAP.md@v1.4.15` 为 SSOT；规则真源仍是各 repo 的 `CLAUDE.md`、直接或目录继承的 `AGENTS.md`、tzhOS / AUM registry、仓库 CI gate 与当前任务契约。
 
 ## Principles
 
@@ -19,7 +19,7 @@
 
 | Layer | Owner | Purpose | Verification |
 |-------|-------|---------|--------------|
-| Active repo inventory | tzhOS `40-PPR/REPO-MAP.md@v1.4.12` | 26 active repos, paths, visibility, Write-Owner, repo-level constraints | `bash 40-PPR/check-deps.sh` in tzhOS |
+| Active repo inventory | tzhOS `40-PPR/REPO-MAP.md@v1.4.15` | 26 active repos, paths, visibility, Write-Owner, repo-level constraints | `bash 40-PPR/check-deps.sh` in tzhOS |
 | Entry coverage | tzhOS `40-PPR/check-deps.sh` | Dynamic check that every active repo has a direct or inherited `AGENTS.md` / `CLAUDE.md` entry | tzhOS governance-check / local `check-deps.sh` |
 | Projection drift | sentinel-shared D-10 | Repo-local scan for stale owner/runtime projection and oversized duplicated `AGENTS.md` files | `bash scripts/precheck-agent-governance.sh` from target repo root |
 | Map invariants | sentinel-shared tests | Prevent this map from becoming a second stale repo inventory | `bash tests/test-agent-governance.sh` |
@@ -32,7 +32,7 @@ This table records only exceptions and important entry topology. It is not a ful
 |-------|-------------|--------------|------------|-------|
 | `super-founder` | root `AGENTS.md` thin entry | root `CLAUDE.md` long-form project rules | `CLAUDE.md` + tzhOS R-0122 / AUM | Root `AGENTS.md` must stay thin; D-10 blocks stale NODE-A and long duplicated governance sections. |
 | `sentinel-shared` | root `AGENTS.md` thin entry | root `CLAUDE.md` hub rules | `CLAUDE.md` + this map | Changes to Agent governance scripts/docs require `bash tests/test-agent-governance.sh`. |
-| `hl-app-certificates` | inherited `huanlong/AGENTS.md` | none at repo root | tzhOS `REPO-MAP.md@v1.4.12` + repo README/security boundary | Signing asset repository; Sentinel caller is deterministic-only / `skip_llm: true`; `.p8` material must stay in Secret Store. |
+| `hl-app-certificates` | inherited `huanlong/AGENTS.md` | none at repo root | tzhOS `REPO-MAP.md@v1.4.15` + repo README/security boundary | Signing asset repository; Sentinel caller is deterministic-only / `skip_llm: true`; `.p8` material must stay in Secret Store. |
 
 ## Drift Rules
 

--- a/tests/test-agent-governance.sh
+++ b/tests/test-agent-governance.sh
@@ -45,7 +45,7 @@ TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
 MAP_DOC_CONTENT="$(cat "$MAP_DOC")"
-assert_contains "$MAP_DOC_CONTENT" "REPO-MAP.md@v1.4.12"
+assert_contains "$MAP_DOC_CONTENT" "REPO-MAP.md@v1.4.15"
 assert_contains "$MAP_DOC_CONTENT" "不在本文件维护 26 仓逐仓清单"
 assert_contains "$MAP_DOC_CONTENT" "40-PPR/check-deps.sh"
 assert_contains "$MAP_DOC_CONTENT" "hl-app-certificates"

--- a/tests/test-caller-targets.sh
+++ b/tests/test-caller-targets.sh
@@ -23,8 +23,8 @@ cat > "$REPO_MAP" <<'MAP'
 | 仓库 | 域 | 本地路径 | 角色 | 可见性 | Write-Owner | 治理约束 |
 |------|----|---------|------|--------|-------------|---------|
 | **tzhOS** | _governance | `01_Repos/_governance/tzhOS` | 治理 SSOT | private | NODE-M | 自身即最高治理层 |
-| **ltc-endpoint** | _governance | `01_Repos/_governance/ltc-endpoint` | LTC | private | NODE-M | R-0092 |
-| **sentinel-shared** | _infra | `01_Repos/_infra/sentinel-shared` | Hub | public | NODE-M | tzhOS Sentinel |
+| **ltc-endpoint** | huanlong | `01_Repos/huanlong/ltc-endpoint` | LTC | private | NODE-M | R-0092 |
+| **sentinel-shared** | huanlong | `01_Repos/huanlong/sentinel-shared` | Hub | public | NODE-M | tzhOS Sentinel |
 | **tech-cofounder-bot** | _infra | `01_Repos/_infra/tech-cofounder-bot` | Runtime | private | NODE-M | MAIA |
 | **tzh-context-atlas** | _infra | `01_Repos/_infra/tzh-context-atlas` | Context Atlas | private | NODE-M | tzhOS |
 | **hl-scene-design-system** | huanlong | `01_Repos/huanlong/hl-scene-design-system` | Design system | private | NODE-E | hl-contracts |


### PR DESCRIPTION
## Summary
- 将 sentinel-shared 的治理文档锚点同步到 REPO-MAP.md@v1.4.15。
- 修正测试样例中的本地路径为 huanlong/sentinel-shared。

## Why
sentinel-shared 已从旧位置归入 huanlong 产品线，多处治理引用需要与 tzhOS 仓库地图保持一致。

## Impact
- 文档与测试夹具路径更正。
- 不改产品运行逻辑。

## Verification
- sentinel-shared 相关测试通过。
- workspace check-deps.sh: PASS 106 / FAIL 0 / WARN 0 / SKIP 7.