### PR TITLE
治理：固化 Agent 治理落点判定标准

### DIFF
--- a/docs/agents-governance-map.md
+++ b/docs/agents-governance-map.md
@@ -1,7 +1,7 @@
 # HuanlongAI AGENTS Governance Map
 
 > Status: ACTIVE
-> Last updated: 2026-06-17
+> Last updated: 2026-06-21
 > Owner: NODE-M operational authority; AUM / tzhOS remain governance SSOT
 
 本文件是 `huanlongAI` 工作区的 Agent 入口治理地图，不是新的仓库清单真源，也不是新的规则真源。活跃仓库清单以 tzhOS `40-PPR/REPO-MAP.md@v1.4.15` 为 SSOT；规则真源仍是各 repo 的 `CLAUDE.md`、直接或目录继承的 `AGENTS.md`、tzhOS / AUM registry、仓库 CI gate 与当前任务契约。
@@ -24,6 +24,17 @@
 | Projection drift | sentinel-shared D-10 | Repo-local scan for stale owner/runtime projection and oversized duplicated `AGENTS.md` files | `bash scripts/precheck-agent-governance.sh` from target repo root |
 | Map invariants | sentinel-shared tests | Prevent this map from becoming a second stale repo inventory | `bash tests/test-agent-governance.sh` |
 
+## Placement Decision Standard
+
+Use this order when deciding where to place a new Agent governance rule, check, or instruction:
+
+1. If the concern defines active repo inventory, formal paths, visibility, Write-Owner, or node role authority, update tzhOS `40-PPR/REPO-MAP.md` or its owning governance spec. Do not implement executable checks there unless that tzhOS spec already owns the checker.
+2. If the concern is cross-repo Agent entrypoint or projection drift, extend sentinel-shared D-10 in `scripts/precheck-agent-governance.sh`, `tests/test-agent-governance.sh`, and this map.
+3. If the concern changes role cards, Skills, dispatch packs, or runtime configuration templates, place it in `tzh-agent-configs`; then run the relevant Sentinel / D-10 checks.
+4. If the concern is only repo-local behavior, keep it in that repo's `AGENTS.md` / `CLAUDE.md`; promote to D-10 only after it becomes a repeated cross-repo drift pattern.
+
+If the concern is cross-repo Agent entrypoint or projection drift, extend sentinel-shared D-10. Do not ask the Founder to choose among tzhOS, sentinel-shared, and tzh-agent-configs again for this class of decision; apply this standard and report the chosen placement with evidence.
+
 ## Exception Map
 
 This table records only exceptions and important entry topology. It is not a full repo inventory.
@@ -40,6 +51,9 @@ Sentinel D-10 blocks:
 
 - root `CLAUDE.md` without root `AGENTS.md`;
 - stale `Write-Owner: NODE-A` / `NODE-M + NODE-A` projections;
+- stale Huanlong fixed repository-count projections such as `6 Git` / `6 仓库` / `六仓库`;
+- stale formal path projections for `sentinel-shared` under `_platform/` or `ltc-endpoint` under `_governance/`;
+- root startup phase snapshots that should point to live repo `PROGRESS.json`, current handoff, or task contracts instead;
 - stale narrow `NODE-M` read-only projections for Huanlong active repos;
 - stale `GHThemeManager.current` theme guidance;
 - long `AGENTS.md` files over 32 KiB;

--- a/scripts/precheck-agent-governance.sh
+++ b/scripts/precheck-agent-governance.sh
@@ -59,6 +59,22 @@ while IFS= read -r file; do
     add_issue "$file contains stale NODE-A Write-Owner projection"
   fi
 
+  if grep -nE '(6[[:space:]]*Git|6[[:space:]]*仓库|六[[:space:]]*(个)?仓库)' "$file" >/dev/null 2>&1; then
+    add_issue "$file contains stale Huanlong fixed repository-count projection"
+  fi
+
+  if grep -nE '(^|[^[:alnum:]_])(01_Repos/)?_platform/sentinel-shared([^[:alnum:]_]|$)' "$file" >/dev/null 2>&1; then
+    add_issue "$file contains stale sentinel-shared path projection"
+  fi
+
+  if grep -nE '(^|[^[:alnum:]_])(01_Repos/)?_governance/ltc-endpoint([^[:alnum:]_]|$)' "$file" >/dev/null 2>&1; then
+    add_issue "$file contains stale ltc-endpoint path projection"
+  fi
+
+  if grep -nF '当前阶段快照' "$file" >/dev/null 2>&1; then
+    add_issue "$file contains stale root phase snapshot projection"
+  fi
+
   if grep -nE 'NODE-M[^\n]*(默认只读|read-only)[^\n]*(huanlong|hl-contracts|hl-platform|hl-framework|hl-factory|hl-console-native|hl-dispatch|team-memory)' "$file" >/dev/null 2>&1; then
     add_issue "$file contains stale NODE-M narrow read-only projection"
   fi

--- a/tests/test-agent-governance.sh
+++ b/tests/test-agent-governance.sh
@@ -51,6 +51,9 @@ assert_contains "$MAP_DOC_CONTENT" "40-PPR/check-deps.sh"
 assert_contains "$MAP_DOC_CONTENT" "hl-app-certificates"
 assert_contains "$MAP_DOC_CONTENT" ".build/checkouts"
 assert_contains "$MAP_DOC_CONTENT" ".claude/worktrees"
+assert_contains "$MAP_DOC_CONTENT" "Placement Decision Standard"
+assert_contains "$MAP_DOC_CONTENT" "If the concern is cross-repo Agent entrypoint or projection drift, extend sentinel-shared D-10"
+assert_contains "$MAP_DOC_CONTENT" "Do not ask the Founder to choose among tzhOS, sentinel-shared, and tzh-agent-configs again"
 pass "keeps AGENTS governance map anchored to REPO-MAP SSOT"
 
 # Missing Codex entrypoint is blocked when CLAUDE.md exists.
@@ -92,6 +95,33 @@ fi
 assert_contains "$STALE_OUTPUT" "stale NODE-A Write-Owner projection"
 assert_contains "$STALE_OUTPUT" "stale GHThemeManager.current projection"
 pass "blocks stale owner and theme projections"
+
+# Root startup map drift is blocked before stale workspace projections reach agents.
+ROOT_MAP_DRIFT_REPO="$TMP_ROOT/root-map-drift"
+make_repo "$ROOT_MAP_DRIFT_REPO"
+cat > "$ROOT_MAP_DRIFT_REPO/AGENTS.md" <<'EOF'
+# Workspace AGENTS
+
+01_Repos/
+├── huanlong/ # 唤龙平台产品线（6 Git 仓库 + 共享协议）
+├── _platform/sentinel-shared/ # Consistency Sentinel
+
+## 5. 当前阶段快照（2026-04-05）
+EOF
+cat > "$ROOT_MAP_DRIFT_REPO/CLAUDE.md" <<'EOF'
+# Workspace CLAUDE
+EOF
+set +e
+ROOT_MAP_DRIFT_OUTPUT=$(run_check "$ROOT_MAP_DRIFT_REPO")
+ROOT_MAP_DRIFT_CODE=$?
+set -e
+if [ "$ROOT_MAP_DRIFT_CODE" -eq 0 ]; then
+  fail "expected stale root startup map projections to fail"
+fi
+assert_contains "$ROOT_MAP_DRIFT_OUTPUT" "stale Huanlong fixed repository-count projection"
+assert_contains "$ROOT_MAP_DRIFT_OUTPUT" "stale sentinel-shared path projection"
+assert_contains "$ROOT_MAP_DRIFT_OUTPUT" "stale root phase snapshot projection"
+pass "blocks stale root startup map projections"
 
 # Long duplicate AGENTS.md is blocked.
 LONG_REPO="$TMP_ROOT/long-agents"


### PR DESCRIPTION
## 摘要

- 在 `docs/agents-governance-map.md` 增加 Placement Decision Standard，固化同类问题的落点判定顺序。
- 扩展 D-10 Agent Governance 检查，拦截旧 Huanlong 固定仓库数量、旧 `sentinel-shared` / `ltc-endpoint` 正式路径、根级阶段快照投影。
- 增加测试覆盖，确保后续 AI 遇到跨仓 Agent 入口 / 投影漂移问题时直接扩展 `sentinel-shared` D-10，不再重复询问落点。

## 背景

本轮仓库治理发现根级启动文件曾残留旧仓库数量、旧 owner / path 和过期阶段快照。问题本质不是 tzhOS 真源定义，而是跨仓 Agent 入口与投影漂移，因此应由 `sentinel-shared` 的 D-10 检查兜底。

## 影响面

- 只影响 `sentinel-shared` 的 D-10 检查、对应测试和 AGENTS 治理地图。
- 不改 tzhOS REPO-MAP 真源。
- 不引入新的仓库清单副本。

## 验证

- `bash tests/test-agent-governance.sh`：8 项通过。
- `bash tests/test-self-test-workflow.sh`：通过。
- `bash -n scripts/precheck-agent-governance.sh tests/test-agent-governance.sh`：通过。
- `git diff --check`：通过。
- D-10 在真实仓根运行通过：`D-10 PASS`。