### PR TITLE
修复 GitHub 中文门禁报告脚本

### DIFF
--- a/.github/workflows/github-language-gate.yml
+++ b/.github/workflows/github-language-gate.yml
@@ -44,19 +44,19 @@ jobs:
           GATE_WARNINGS: ${{ steps.language_gate.outputs.warnings }}
           ISSUE_NUMBER: ${{ steps.language_gate.outputs.target_issue_number }}
         run: |
-          cat > "$RUNNER_TEMP/github-language-gate-comment.md" <<EOF
-          ## GitHub Issue / Comment 门禁未通过
-
-          检测目标：$GATE_TARGET_URL
-
-          门禁状态：$GATE_STATUS
-
-          错误码：$GATE_ERRORS$GATE_WARNINGS
-
-          请将 Issue（事项）标题、正文或评论补充简体中文说明后重新编辑。英文术语、命令、路径、字段名和日志可以保留，但不能提交纯英文内容。
-
-          如果评论使用 `<!-- ai-output:v1 -->`，请补齐类型、结论、依据、当前状态、下一步唯一动作、需要人处理、不确定项，并确保判断词带证据。
-          EOF
+          {
+            printf '%s\n' '## GitHub Issue / Comment 门禁未通过'
+            printf '\n'
+            printf '检测目标：%s\n' "$GATE_TARGET_URL"
+            printf '\n'
+            printf '门禁状态：%s\n' "$GATE_STATUS"
+            printf '\n'
+            printf '错误码：%s%s\n' "$GATE_ERRORS" "$GATE_WARNINGS"
+            printf '\n'
+            printf '%s\n' '请将 Issue（事项）标题、正文或评论补充简体中文说明后重新编辑。英文术语、命令、路径、字段名和日志可以保留，但不能提交纯英文内容。'
+            printf '\n'
+            printf '%s\n' '如果评论使用 `<!-- ai-output:v1 -->`，请补齐类型、结论、依据、当前状态、下一步唯一动作、需要人处理、不确定项，并确保判断词带证据。'
+          } > "$RUNNER_TEMP/github-language-gate-comment.md"
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/github-language-gate-comment.md"
 
       - name: Fail GitHub issue/comment gate

--- a/tests/test-github-language-gate-workflow.sh
+++ b/tests/test-github-language-gate-workflow.sh
@@ -40,6 +40,8 @@ assert_file_contains "$WORKFLOW" "GitHub Issue / Comment 门禁未通过"
 assert_file_contains "$WORKFLOW" "ai-output:v1"
 assert_file_contains "$WORKFLOW" "gh issue comment"
 assert_file_contains "$WORKFLOW" "inputs.report_comment"
+assert_file_contains "$WORKFLOW" "printf '%s\\n'"
+assert_file_not_contains "$WORKFLOW" "<<EOF"
 assert_file_not_contains "$WORKFLOW" "permissions:"
 
 assert_file_contains "$MATRIX" "GPC-008"


### PR DESCRIPTION
## 变更
- 将 GitHub language gate 报告生成从未引用 heredoc 改为 `printf` block。
- 避免正文中的反引号和 `<!-- ai-output:v1 -->` 被 shell 当成命令替换解析。
- 更新 workflow 测试，禁止回归到未引用 heredoc。

## 背景
门禁已经能检测英文 issue/comment，但报告步骤曾因 shell heredoc/backtick 解析失败，导致 issue 级提醒没有可靠写回。

## 验证
- `python3 tests/test-github-language-gate.py`：13 tests OK。
- `bash tests/test-github-language-gate-workflow.sh`：passed。
- `bash tests/test-agent-governance.sh`：8 tests passed。

## 说明
此 PR 只进入 Draft Review，不代表 merge、release 或生产生效。