### PR TITLE
修复 Sentinel LLM 429 限流恢复路径

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -374,6 +374,7 @@ LLM_CHECKS=$(yaml_get_nested_array "$CONFIG_FILE" "llm" "checks")
 CONFIDENCE_THRESHOLD=$(yaml_get_nested "$CONFIG_FILE" "llm" "confidence_threshold" "0.7")
 CONFIG_PROVIDER=$(yaml_get_nested "$CONFIG_FILE" "llm" "provider" "auto")
 REQUESTED_PROVIDER="${SENTINEL_LLM_PROVIDER:-$CONFIG_PROVIDER}"
+ANTHROPIC_MODEL="$LLM_MODEL"
 HEIYUCODE_BASE_URL="${HEIYUCODE_BASE_URL:-$(yaml_get_nested "$CONFIG_FILE" "llm" "heiyucode_base_url" "https://www.heiyucode.com")}"
 HEIYUCODE_API_URL="${HEIYUCODE_API_URL:-${HEIYUCODE_BASE_URL%/}/v1/messages}"
 HEIYUCODE_MODEL="${HEIYUCODE_MODEL:-$(yaml_get_nested "$CONFIG_FILE" "llm" "heiyucode_model" "$LLM_MODEL")}"
@@ -587,39 +588,102 @@ PROVIDER_STDERR_BYTES="${PROVIDER_STDERR_BYTES:-0}"
 PROVIDER_ATTEMPTS="${PROVIDER_ATTEMPTS:-0}"
 PROVIDER_BASE_URL_CONFIGURED="${PROVIDER_BASE_URL_CONFIGURED:-false}"
 PROVIDER_API_URL_CONFIGURED="${PROVIDER_API_URL_CONFIGURED:-false}"
+ANTHROPIC_ERROR_REASON=""
 
-if [ "$LLM_PROVIDER" = "anthropic" ]; then
+call_anthropic_provider() {
+  local api_response api_error curl_status started response_text
+
+  LLM_PROVIDER="anthropic"
+  LLM_MODEL="$ANTHROPIC_MODEL"
+  PROVIDER_TRANSPORT="messages-api"
+  PROVIDER_HTTP_STATUS="n/a"
+  PROVIDER_AUTH_HEADER_KIND="x-api-key"
+  PROVIDER_EXIT_CODE="0"
+  PROVIDER_ATTEMPTS="1"
+  PROVIDER_DURATION_SECONDS="0"
+  PROVIDER_STDOUT_BYTES="0"
+  PROVIDER_STDERR_BYTES="0"
+  PROVIDER_BASE_URL_CONFIGURED=false
+  PROVIDER_API_URL_CONFIGURED=true
+
   if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    echo "::error::ANTHROPIC_API_KEY not set — fail closed"
-    write_error_result "ANTHROPIC_API_KEY not configured"
-    exit 1
+    ANTHROPIC_ERROR_REASON="ANTHROPIC_API_KEY not configured"
+    return 1
   fi
 
-  API_RESPONSE=$(curl -s --max-time 120 \
+  build_messages_request_body "$REQUEST_BODY"
+  started="$(date +%s)"
+  set +e
+  api_response=$(curl -s --max-time 120 \
     -H "Content-Type: application/json" \
     -H "x-api-key: ${ANTHROPIC_API_KEY}" \
     -H "anthropic-version: 2023-06-01" \
     --data-binary "@${REQUEST_BODY}" \
-    "https://api.anthropic.com/v1/messages" 2>&1) || true
+    "https://api.anthropic.com/v1/messages" 2>&1)
+  curl_status="$?"
+  set -e
 
-  if [ -z "$API_RESPONSE" ]; then
-    echo "::error::Claude API returned empty response — fail closed"
-    write_error_result "Empty API response"
-    exit 1
+  PROVIDER_EXIT_CODE="$curl_status"
+  PROVIDER_DURATION_SECONDS="$(( $(date +%s) - started ))"
+  PROVIDER_STDOUT_BYTES="${#api_response}"
+
+  if [ "$curl_status" -ne 0 ]; then
+    ANTHROPIC_ERROR_REASON="Claude API curl error"
+    return 1
   fi
 
-  API_ERROR=$(echo "$API_RESPONSE" | jq -r '.error.message // empty' 2>/dev/null || true)
-  if [ -n "$API_ERROR" ]; then
-    echo "::error::Claude API error: $API_ERROR — fail closed"
-    write_error_result "API error: ${API_ERROR}"
-    exit 1
+  if [ -z "$api_response" ]; then
+    ANTHROPIC_ERROR_REASON="Empty API response"
+    return 1
   fi
 
-  RESPONSE_TEXT=$(echo "$API_RESPONSE" | jq -r '.content[0].text // empty' 2>/dev/null || true)
+  api_error=$(printf '%s\n' "$api_response" | jq -r '.error.message // empty' 2>/dev/null || true)
+  if [ -n "$api_error" ]; then
+    ANTHROPIC_ERROR_REASON="API error: ${api_error}"
+    return 1
+  fi
+
+  response_text=$(printf '%s\n' "$api_response" | jq -r '.content[0].text // empty' 2>/dev/null || true)
+  if [ -z "$response_text" ]; then
+    ANTHROPIC_ERROR_REASON="No text in response"
+    return 1
+  fi
+
+  RESPONSE_TEXT="$response_text"
+  return 0
+}
+
+can_fallback_to_anthropic() {
+  [ "$REQUESTED_PROVIDER" = "auto" ] && [ -n "${ANTHROPIC_API_KEY:-}" ]
+}
+
+fallback_to_anthropic_after_heiyucode_error() {
+  local reason="$1"
+  if ! can_fallback_to_anthropic; then
+    return 1
+  fi
+
+  echo "::warning::${reason}; falling back to Anthropic provider"
+  if call_anthropic_provider; then
+    return 0
+  fi
+
+  echo "::error::Anthropic fallback failed after HeiyuCode provider error: ${ANTHROPIC_ERROR_REASON} — fail closed"
+  write_error_result "Anthropic fallback failed after HeiyuCode provider error: ${ANTHROPIC_ERROR_REASON}"
+  exit 1
+}
+
+if [ "$LLM_PROVIDER" = "anthropic" ]; then
+  if ! call_anthropic_provider; then
+    echo "::error::${ANTHROPIC_ERROR_REASON} — fail closed"
+    write_error_result "$ANTHROPIC_ERROR_REASON"
+    exit 1
+  fi
 elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   PROVIDER_TRANSPORT="messages-api"
   PROVIDER_HTTP_STATUS="n/a"
   PROVIDER_AUTH_HEADER_KIND="n/a"
+  HEIYUCODE_FALLBACK_SUCCEEDED=false
 
   if [ -z "$HEIYUCODE_TOKEN" ]; then
     write_provider_error_result "HeiyuCode token not configured" 0 0 /dev/null /dev/null
@@ -665,7 +729,7 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
 
   is_retryable_http_status() {
     case "$1" in
-      500|502|503|504|520|522|524)
+      429|500|502|503|504|520|522|524)
         return 0
         ;;
       *)
@@ -723,35 +787,61 @@ elif [ "$LLM_PROVIDER" = "heiyucode_claude_code" ]; then
   done
 
   if [ "$client_status" -eq 124 ]; then
-    write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 1
-  fi
-  if [ "$client_status" -ne 0 ]; then
-    write_provider_error_result "HeiyuCode Messages API curl error" "$client_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 1
-  fi
-
-  if ! [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
-    if [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; then
-      write_provider_error_result "HeiyuCode Messages API auth error HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+    if fallback_to_anthropic_after_heiyucode_error "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s"; then
+      HEIYUCODE_FALLBACK_SUCCEEDED=true
     else
-      write_provider_error_result "HeiyuCode Messages API HTTP ${HTTP_STATUS}" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+      write_provider_error_result "HeiyuCode Messages API timeout after ${HEIYUCODE_CLIENT_TIMEOUT_SECONDS}s" 124 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+      exit 1
     fi
-    exit 1
+  fi
+  if [ "$HEIYUCODE_FALLBACK_SUCCEEDED" != true ] && [ "$client_status" -ne 0 ]; then
+    if fallback_to_anthropic_after_heiyucode_error "HeiyuCode Messages API curl error"; then
+      HEIYUCODE_FALLBACK_SUCCEEDED=true
+    else
+      write_provider_error_result "HeiyuCode Messages API curl error" "$client_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+      exit 1
+    fi
   fi
 
-  set +e
-  RESPONSE_TEXT="$(jq -r '[.content[]? | select(.type == "text") | .text] | join("\n\n")' "$API_RESPONSE_FILE" 2>"$API_ERR_FILE")"
-  parse_status="$?"
-  set -e
-  if [ "$parse_status" -ne 0 ]; then
-    write_provider_error_result "HeiyuCode Messages API returned invalid JSON" "$parse_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 1
+  if [ "$HEIYUCODE_FALLBACK_SUCCEEDED" != true ] && ! [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]]; then
+    heiyucode_http_reason="HeiyuCode Messages API HTTP ${HTTP_STATUS}"
+    if [ "$HTTP_STATUS" = "401" ] || [ "$HTTP_STATUS" = "403" ]; then
+      heiyucode_http_reason="HeiyuCode Messages API auth error HTTP ${HTTP_STATUS}"
+    fi
+    if fallback_to_anthropic_after_heiyucode_error "$heiyucode_http_reason"; then
+      HEIYUCODE_FALLBACK_SUCCEEDED=true
+    else
+      write_provider_error_result "$heiyucode_http_reason" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+      exit 1
+    fi
   fi
 
-  if [ -z "$RESPONSE_TEXT" ]; then
-    write_provider_error_result "No text in response" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
-    exit 1
+  if [ "$HEIYUCODE_FALLBACK_SUCCEEDED" != true ]; then
+    set +e
+    RESPONSE_TEXT="$(jq -r '[.content[]? | select(.type == "text") | .text] | join("\n\n")' "$API_RESPONSE_FILE" 2>"$API_ERR_FILE")"
+    parse_status="$?"
+    set -e
+    if [ "$parse_status" -ne 0 ]; then
+      if fallback_to_anthropic_after_heiyucode_error "HeiyuCode Messages API returned invalid JSON"; then
+        HEIYUCODE_FALLBACK_SUCCEEDED=true
+      else
+        write_provider_error_result "HeiyuCode Messages API returned invalid JSON" "$parse_status" "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+        exit 1
+      fi
+    fi
+  fi
+
+  if [ "$HEIYUCODE_FALLBACK_SUCCEEDED" != true ] && [ -z "$RESPONSE_TEXT" ]; then
+    if fallback_to_anthropic_after_heiyucode_error "No text in response"; then
+      HEIYUCODE_FALLBACK_SUCCEEDED=true
+    else
+      write_provider_error_result "No text in response" 0 "$client_duration" "$API_RESPONSE_FILE" "$API_ERR_FILE"
+      exit 1
+    fi
+  fi
+
+  if [ "$HEIYUCODE_FALLBACK_SUCCEEDED" = true ]; then
+    echo "HeiyuCode provider failed; Anthropic fallback response received"
   fi
 fi
 

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -74,7 +74,7 @@ test_anthropic_provider_uses_messages_api() {
   cat > "$fake_bin/curl" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+printf '%s\n' "$*" >> "$FAKE_CALL_DIR/curl.args"
 cat <<'JSON'
 {"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.95,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}
 JSON
@@ -101,7 +101,7 @@ write_fake_heiyucode_curl() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf '%s\n' "$*" > "$FAKE_CALL_DIR/curl.args"
+printf '%s\n' "$*" >> "$FAKE_CALL_DIR/curl.args"
 
 out=""
 while [ "$#" -gt 0 ]; do
@@ -119,6 +119,13 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+if grep -q "https://api.anthropic.com/v1/messages" "$FAKE_CALL_DIR/curl.args"; then
+  cat <<'JSON'
+{"content":[{"text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.97,\"reason\":\"anthropic fallback ok\"}},\"summary\":\"anthropic fallback ok\"}"}]}
+JSON
+  exit 0
+fi
 
 count_file="$FAKE_CALL_DIR/curl.count"
 count=0
@@ -186,6 +193,16 @@ EOF
     ;;
   http_500)
     write_response 500 '{"error":{"message":"upstream unavailable"}}'
+    ;;
+  http_429_then_pass)
+    if [ "$count" -eq 1 ]; then
+      write_response 429 '{"error":{"message":"rate limited"}}'
+    else
+      write_response 200 '{"content":[{"type":"text","text":"{\"verdict\":\"PASS\",\"checks\":{\"GPC-003\":{\"verdict\":\"PASS\",\"confidence\":0.96,\"reason\":\"ok\"}},\"summary\":\"ok\"}"}]}'
+    fi
+    ;;
+  http_429_always)
+    write_response 429 '{"error":{"message":"rate limited"}}'
     ;;
   http_524_then_pass)
     if [ "$count" -eq 1 ]; then
@@ -676,6 +693,71 @@ test_heiyucode_provider_retries_retryable_524_once() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Retryable 524 retry result mismatch"
 }
 
+test_heiyucode_provider_retries_retryable_429_once() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="http_429_then_pass" \
+      SENTINEL_LLM_PROVIDER="heiyucode" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  [ "$(cat "$calls/curl.count")" = "2" ] || fail "Retryable 429 should be retried exactly once"
+  jq -e '
+    .provider == "heiyucode_claude_code"
+    and .transport == "messages-api"
+    and .http_status == "200"
+    and .attempts == 2
+    and .passed == true
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Retryable 429 retry result mismatch"
+}
+
+test_auto_falls_back_to_anthropic_after_heiyucode_http_429() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="http_429_always" \
+      SENTINEL_LLM_PROVIDER="auto" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  [ "$(cat "$calls/curl.count")" = "2" ] || fail "Fallback path should retry HeiyuCode once before Anthropic"
+  grep -q "https://www.heiyucode.com/v1/messages" "$calls/curl.args" || fail "HeiyuCode URL was not attempted"
+  grep -q "https://api.anthropic.com/v1/messages" "$calls/curl.args" || fail "Anthropic fallback URL was not attempted"
+  jq -e '
+    .provider == "anthropic"
+    and .model == "claude-test-model"
+    and .transport == "messages-api"
+    and .passed == true
+    and .attempts == 1
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Anthropic fallback result mismatch"
+}
+
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure() {
   local tmp fake_bin calls
   tmp="$(mktemp -d)"
@@ -1063,6 +1145,8 @@ test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json
 test_heiyucode_provider_recovers_malformed_fenced_pass_json
 test_heiyucode_provider_http_error_fails_closed_with_response_tail
 test_heiyucode_provider_retries_retryable_524_once
+test_heiyucode_provider_retries_retryable_429_once
+test_auto_falls_back_to_anthropic_after_heiyucode_http_429
 test_heiyucode_provider_retries_x_api_key_after_bearer_auth_failure
 test_aggregate_includes_llm_review_failure
 test_aggregate_fails_closed_when_required_result_is_missing


### PR DESCRIPTION
## 变更内容

- 将 HeiyuCode Messages API 的 HTTP 429 纳入 `llm-review.sh` retryable HTTP 范围。
- 在 `llm_provider: auto` 且 `ANTHROPIC_API_KEY` 可用时，HeiyuCode provider 错误后 fallback 到 Anthropic。
- 补充 429 retry 与 auto fallback 的回归测试。

## 原因

`hl-scene-app#61` 的 Consistency Sentinel 两次失败均为 `llm-review` 命中 `HeiyuCode Messages API HTTP 429`，确定性检查 8/8 通过，属于外部 LLM provider 限流导致的全局门禁误伤风险。

## 影响

- 不改变确定性 D-1/D-2/D-3/D-4/D-5/D-6/D-10/D-12 gate。
- 不把 LLM provider 错误直接放行为通过；HeiyuCode retry 和备用 provider 均失败时仍 fail closed。
- 仅在 `auto` 模式且备用 Anthropic secret 存在时 fallback；显式 `heiyucode` 模式仍使用 HeiyuCode 并 fail closed。

## 护栏

- 不读取、不输出任何 secret。
- 只记录 provider、HTTP status、attempts 等非敏感诊断字段。
- 保留 LLM 显式 `FAIL` / `ESCALATE` 的阻断语义。

## 验证命令

```bash
bash -n scripts/llm-review.sh
bash -n tests/test-llm-review-provider-router.sh
bash tests/test-llm-review-provider-router.sh
bash tests/test-policy-file.sh
bash tests/test-d7-d8.sh
bash tests/test-caller-sync-workflow.sh
bash tests/test-caller-targets.sh
bash tests/test-caller-token-write-probe-workflow.sh
bash tests/test-dashboard-workflow.sh
bash tests/test-cascade-workflow.sh
bash tests/test-llm-review-provider-router.sh
bash tests/test-llm-message-client.sh
bash tests/test-aux-llm-workflows.sh
bash tests/test-owner-reviewed-override.sh
bash tests/test-review-gate-audit.sh
bash tests/test-agent-governance.sh
python3 tests/test-github-language-gate.py
bash tests/test-github-language-gate-workflow.sh
python3 tests/test-pr-doc-readability.py
bash tests/test-pr-doc-readability-workflow.sh
bash tests/test-self-test-workflow.sh
bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh
ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }'\ngit diff --check\n```\n\n本地结果：以上命令均通过。