### PR TITLE
fix: HeiyuCode 非 JSON review 时启用 auto fallback

### DIFF
--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -864,6 +864,24 @@ write_review_parse_error() {
   fi
 }
 
+fallback_to_anthropic_after_heiyucode_review_parse_error() {
+  local reason="$1"
+  if [ "$LLM_PROVIDER" != "heiyucode_claude_code" ]; then
+    return 1
+  fi
+  if ! can_fallback_to_anthropic; then
+    return 1
+  fi
+
+  if fallback_to_anthropic_after_heiyucode_error "$reason"; then
+    API_RESPONSE_FILE=""
+    API_ERR_FILE=""
+    return 0
+  fi
+
+  return 1
+}
+
 recover_malformed_review_json() {
   local checks_file
   checks_file="$(mktemp)"
@@ -915,21 +933,35 @@ print(json.dumps({
   rm -f "$checks_file"
 }
 
+extract_review_json_from_response() {
+  local response_text="$1"
+  local review_json
+
+  review_json=$(printf '%s\n' "$response_text" | sed -n '/^{/,/^}/p' || true)
+  if [ -z "$review_json" ]; then
+    review_json=$(printf '%s\n' "$response_text" | sed -n '/```json/,/```/p' | grep -v '```' || true)
+  fi
+  if [ -z "$review_json" ]; then
+    review_json=$(printf '%s\n' "$response_text" | sed -n '/```/,/```/p' | grep -v '```' || true)
+  fi
+
+  printf '%s\n' "$review_json"
+}
+
 # Extract JSON from response
-REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/^{/,/^}/p' || true)
-if [ -z "$REVIEW_JSON" ]; then
-  REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/```json/,/```/p' | grep -v '```' || true)
-fi
-if [ -z "$REVIEW_JSON" ]; then
-  REVIEW_JSON=$(echo "$RESPONSE_TEXT" | sed -n '/```/,/```/p' | grep -v '```' || true)
-fi
+REVIEW_JSON=$(extract_review_json_from_response "$RESPONSE_TEXT")
 
 # Validate JSON and extract verdict
 VERDICT="ESCALATE"
 PASSED=true
 if [ -z "$(printf '%s' "$REVIEW_JSON" | tr -d '[:space:]')" ]; then
-  write_review_parse_error "Could not extract LLM review JSON"
-  exit 1
+  if fallback_to_anthropic_after_heiyucode_review_parse_error "Could not extract LLM review JSON"; then
+    REVIEW_JSON=$(extract_review_json_from_response "$RESPONSE_TEXT")
+  fi
+  if [ -z "$(printf '%s' "$REVIEW_JSON" | tr -d '[:space:]')" ]; then
+    write_review_parse_error "Could not extract LLM review JSON"
+    exit 1
+  fi
 fi
 if ! printf '%s\n' "$REVIEW_JSON" | jq -e 'type == "object" and length > 0' >/dev/null 2>&1; then
   RECOVERED_REVIEW_JSON="$(recover_malformed_review_json || true)"

--- a/tests/test-llm-review-provider-router.sh
+++ b/tests/test-llm-review-provider-router.sh
@@ -592,6 +592,40 @@ test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json() {
   ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Non-JSON review diagnostics mismatch"
 }
 
+test_auto_falls_back_to_anthropic_after_heiyucode_non_json_review() {
+  local tmp fake_bin calls
+  tmp="$(mktemp -d)"
+  fake_bin="$tmp/bin"
+  calls="$tmp/calls"
+  mkdir -p "$fake_bin" "$calls"
+  make_repo "$tmp/repo"
+  write_fake_heiyucode_curl "$fake_bin/curl"
+
+  (
+    cd "$tmp/repo"
+    PATH="$fake_bin:$PATH" \
+      FAKE_CALL_DIR="$calls" \
+      FAKE_CURL_MODE="non_json_text" \
+      SENTINEL_LLM_PROVIDER="auto" \
+      HEIYUCODE_AUTH_TOKEN="heiyucode-test-token" \
+      ANTHROPIC_API_KEY="anthropic-test-key" \
+      HEIYUCODE_BASE_URL="https://www.heiyucode.com" \
+      HEIYUCODE_MODEL="claude-heiyu-test" \
+      "$ROOT_DIR/scripts/llm-review.sh"
+  )
+
+  [ "$(cat "$calls/curl.count")" = "1" ] || fail "Fallback path should call HeiyuCode once before Anthropic"
+  grep -q "https://www.heiyucode.com/v1/messages" "$calls/curl.args" || fail "HeiyuCode URL was not attempted"
+  grep -q "https://api.anthropic.com/v1/messages" "$calls/curl.args" || fail "Anthropic fallback URL was not attempted"
+  jq -e '
+    .provider == "anthropic"
+    and .model == "claude-test-model"
+    and .transport == "messages-api"
+    and .passed == true
+    and .attempts == 1
+  ' "$tmp/repo/.sentinel/results/llm-review.json" >/dev/null || fail "Anthropic fallback result mismatch for non-JSON HeiyuCode review"
+}
+
 test_heiyucode_provider_recovers_malformed_fenced_pass_json() {
   local tmp fake_bin calls
   tmp="$(mktemp -d)"
@@ -1142,6 +1176,7 @@ test_heiyucode_provider_timeout_fails_closed_without_waiting_for_job_timeout
 test_heiyucode_provider_nonzero_exit_fails_closed_with_diagnostics
 test_heiyucode_provider_empty_output_fails_closed_with_diagnostics
 test_heiyucode_provider_non_json_review_fails_closed_with_valid_result_json
+test_auto_falls_back_to_anthropic_after_heiyucode_non_json_review
 test_heiyucode_provider_recovers_malformed_fenced_pass_json
 test_heiyucode_provider_http_error_fails_closed_with_response_tail
 test_heiyucode_provider_retries_retryable_524_once


### PR DESCRIPTION
## 变更内容
- 在 `scripts/llm-review.sh` 中抽出 review JSON 提取函数。
- 当 `llm_provider: auto` 且 HeiyuCode 返回 HTTP 200 但 review 文本无法抽取结构化 JSON 时，改为尝试 Anthropic fallback。
- 保留显式 `heiyucode` 模式的 fail-closed 行为，不把非 JSON 文本误判为通过。
- 增加回归测试覆盖 `auto + HeiyuCode 非 JSON review + Anthropic 可用` 场景。

## 原因
`hl-scene-app#61` 最新 rerun 显示 HeiyuCode 已从 HTTP 429 恢复为 HTTP 200，但返回非结构化拒答文本，导致 Sentinel 无法抽取 LLM review JSON 并 fail-closed。该路径不属于业务 PR 内容失败，而是 provider 输出形态异常；当前 `auto` fallback 只覆盖 HTTP/超时/空响应等 provider 错误，未覆盖 review JSON 抽取失败。

## 影响
- 正向影响：减少 HeiyuCode 偶发非 JSON 文本导致的全局治理 PR 红灯。
- 行为边界：只有 `REQUESTED_PROVIDER=auto` 且 Anthropic key 可用时触发 fallback。
- 不改变：显式 HeiyuCode、显式 Anthropic、确定性 Sentinel 检查和 fail-closed 总原则。

## 护栏
- HeiyuCode 显式 provider 仍对非 JSON review fail-closed。
- Anthropic fallback 若也失败，仍 fail-closed。
- fallback 成功后清空旧 HeiyuCode 响应文件引用，避免后续解析失败时写错 provider 诊断。

## 验证命令
- `tests/test-llm-review-provider-router.sh`
- `bash tests/test-llm-message-client.sh`
- `bash tests/test-aux-llm-workflows.sh`
- `bash tests/test-policy-file.sh`
- `bash tests/test-d7-d8.sh`
- `bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-caller-targets.sh`
- `bash tests/test-caller-token-write-probe-workflow.sh`
- `bash tests/test-dashboard-workflow.sh`
- `bash tests/test-cascade-workflow.sh`
- `bash tests/test-owner-reviewed-override.sh`
- `bash tests/test-review-gate-audit.sh`
- `bash tests/test-agent-governance.sh`
- `python3 tests/test-github-language-gate.py`
- `bash tests/test-github-language-gate-workflow.sh`
- `python3 tests/test-pr-doc-readability.py`
- `bash tests/test-pr-doc-readability-workflow.sh`
- `bash tests/test-self-test-workflow.sh`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- `ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.yml\"].each { |file| YAML.load_file(file) }'`
- `git diff --check`

关联：#176