### PR TITLE
fix: 收敛 Sentinel LLM prompt 输出契约

### DIFF
--- a/prompts/sentinel-system.md
+++ b/prompts/sentinel-system.md
@@ -165,24 +165,33 @@ You will analyze staged code changes against a comprehensive set of checks. Each
 - **0.3-0.5:** Weak signal, could be false positive
 - **0.0-0.3:** Unlikely violation, ignore
 
-## Output Format
+## Output Contract
 
-For each check performed, provide:
+Always return exactly one JSON object. Do not wrap it in markdown. Do not add
+prose before or after the JSON object.
+
+If the diff contains suspicious secrets, credentials, tokens, private keys, or
+other sensitive values, do not repeat the value. Report the issue with a short
+description such as "potential secret value present" and use `FAIL` or
+`ESCALATE` as appropriate.
+
+If you cannot confidently assess the diff, or if policy/safety constraints
+prevent a normal review, do not refuse in prose. Return an `ESCALATE` JSON
+verdict with a short reason.
+
+Required schema:
 
 ```json
 {
-  "check_id": "ABC-001",
-  "check_name": "Security Check Name",
-  "passed": false,
-  "findings": [
-    {
-      "line": 42,
-      "severity": "critical|high|medium|low",
-      "message": "Description of the issue",
+  "verdict": "PASS|FAIL|ESCALATE",
+  "checks": {
+    "ABC-001": {
+      "verdict": "PASS|FAIL|ESCALATE",
       "confidence": 0.95,
-      "suggestion": "How to fix this"
+      "reason": "brief explanation"
     }
-  ]
+  },
+  "summary": "one-line summary"
 }
 ```
 
@@ -199,19 +208,12 @@ Use these to inform your review and provide consistent decisions aligned with pr
 
 ## Final Verdict
 
-After analyzing all enabled checks, provide a summary verdict:
+The top-level `verdict` is the final verdict consumed by Sentinel:
 
-```json
-{
-  "overall_verdict": "passed|failed",
-  "total_findings": 0,
-  "critical_issues": 0,
-  "high_issues": 0,
-  "medium_issues": 0,
-  "low_issues": 0,
-  "confidence_average": 0.85
-}
-```
+- `PASS`: no enabled check has a blocking finding.
+- `FAIL`: at least one enabled check has a clear blocking violation.
+- `ESCALATE`: the diff needs owner review, the evidence is ambiguous, or the
+  model cannot safely complete the review without human judgment.
 
 ---
 


### PR DESCRIPTION
## 变更内容
- 将 shared Sentinel system prompt 的旧 `overall_verdict` 示例收敛为当前脚本实际消费的 `verdict/checks/summary` schema。
- 明确要求模型只输出一个 JSON object，不输出 markdown 或前后说明。
- 对疑似 secret / token / credential 场景增加护栏：不得复述敏感值，应以简短原因给出 `FAIL` 或 `ESCALATE`。
- 对无法判断或安全策略阻断场景增加要求：不得返回拒答散文，应输出 `ESCALATE` JSON。

## 原因
`hl-scene-app#61` 在 HeiyuCode HTTP 200 场景仍返回非 JSON 文本，导致 Sentinel 无法抽取 LLM review JSON。`sentinel-shared#177` 已补上 auto fallback，但 Anthropic fallback 当前仍受账务余额阻塞。shared prompt 仍保留旧输出格式示例，容易与 caller user message 的当前 schema 冲突；本 PR 收敛 prompt 契约，降低 HeiyuCode 主路径非 JSON 输出概率。

## 影响
- 影响范围：所有使用 shared prompt 的 Sentinel LLM review。
- 正向影响：提升 JSON 输出稳定性；遇到敏感或无法判断场景时进入 `ESCALATE`，可走 owner-reviewed 机制。
- 不改变：确定性检查、provider fallback、fail-closed 原则、required checks。

## 护栏
- 不要求模型泄露或复述疑似 secret。
- 不把无法判断视为 PASS。
- 不修改 workflow、secret、branch protection 或 caller 仓配置。

## 验证命令
- `rg -n "overall_verdict|Respond ONLY|verdict/checks/summary|Output Contract|ESCALATE" prompts/sentinel-system.md scripts/llm-review.sh`
- `git diff --check`
- `bash -n scripts/*.sh tests/*.sh .sentinel/checks/*.sh`
- `ruby -e 'require \"yaml\"; Dir[\".github/workflows/*.yml\"].each { |file| YAML.load_file(file) }'`
- `bash tests/test-policy-file.sh`
- `bash tests/test-d7-d8.sh`
- `bash tests/test-caller-sync-workflow.sh`
- `bash tests/test-caller-targets.sh`
- `bash tests/test-caller-token-write-probe-workflow.sh`
- `bash tests/test-dashboard-workflow.sh`
- `bash tests/test-cascade-workflow.sh`
- `bash tests/test-llm-review-provider-router.sh`
- `bash tests/test-llm-message-client.sh`
- `bash tests/test-aux-llm-workflows.sh`
- `bash tests/test-owner-reviewed-override.sh`
- `bash tests/test-review-gate-audit.sh`
- `bash tests/test-agent-governance.sh`
- `python3 tests/test-github-language-gate.py`
- `bash tests/test-github-language-gate-workflow.sh`
- `python3 tests/test-pr-doc-readability.py`
- `bash tests/test-pr-doc-readability-workflow.sh`
- `bash tests/test-self-test-workflow.sh`

关联：#176