### PR TITLE
[codex] 修复 Caller Sync 同步提交治理 trailers

### DIFF
--- a/.github/workflows/caller-sync.yml
+++ b/.github/workflows/caller-sync.yml
@@ -211,6 +211,16 @@ jobs:
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_BASE_URL__/$(gha_expr "vars.HEIYUCODE_BASE_URL || 'https://www.heiyucode.com'")}"
           CANONICAL_BODY="${CANONICAL_BODY//__EXPR_HEIYUCODE_MODEL__/$(gha_expr "vars.HEIYUCODE_MODEL || ''")}"
           CALLER_SYNC_TOKEN_REMEDIATION="CASCADE_TOKEN must have repo read/write access to every selected downstream repo and workflow write permission, because caller-sync updates .github/workflows/consistency-sentinel.yml."
+          CALLER_SYNC_COMMIT_MESSAGE="$(cat <<EOF
+          chore(sentinel): sync caller workflow to latest template
+
+          Agent-ID: codex-cli
+          Run-ID: caller-sync-${GITHUB_RUN_ID}
+          WO-ID: sentinel-caller-sync
+          Node-ID: NODE-M
+          Human-Author: tongzhenghui
+          EOF
+          )"
 
           # Normalize canonical: strip comments, leading/trailing whitespace,
           # collapse whitespace for comparison
@@ -368,7 +378,7 @@ jobs:
                   -H "Accept: application/vnd.github+json" \
                   "https://api.github.com/repos/huanlongAI/${REPO}/contents/.github/workflows/consistency-sentinel.yml" \
                   -d "$(jq -n \
-                    --arg msg "chore(sentinel): sync caller workflow to latest template" \
+                    --arg msg "$CALLER_SYNC_COMMIT_MESSAGE" \
                     --arg content "$ENCODED" \
                     --arg sha "$FILE_SHA" \
                     --arg branch "sentinel-caller-sync" \

--- a/tests/test-caller-sync-workflow.sh
+++ b/tests/test-caller-sync-workflow.sh
@@ -103,4 +103,17 @@ do
     || fail "caller-sync workflow missing token diagnostic marker: $expected"
 done
 
+for expected in \
+  'CALLER_SYNC_COMMIT_MESSAGE=' \
+  'Agent-ID: codex-cli' \
+  'Run-ID: caller-sync-${GITHUB_RUN_ID}' \
+  'WO-ID: sentinel-caller-sync' \
+  'Node-ID: NODE-M' \
+  'Human-Author: tongzhenghui' \
+  '--arg msg "$CALLER_SYNC_COMMIT_MESSAGE"'
+do
+  grep -Fq -- "$expected" "$CALLER_SYNC_WORKFLOW" \
+    || fail "caller-sync workflow missing governance trailer marker: $expected"
+done
+
 echo "caller-sync dry_run input handling test passed"


### PR DESCRIPTION
## 变更内容

- 在 `.github/workflows/caller-sync.yml` 中为 Caller Sync 自动生成的同步 commit 增加治理 trailers。
- 新增 `CALLER_SYNC_COMMIT_MESSAGE`，包含 `Agent-ID`、`Run-ID`、`WO-ID`、`Node-ID`、`Human-Author`。
- 扩展 `tests/test-caller-sync-workflow.sh`，防止后续同步 commit 再缺失治理 trailers。

## 原因

`tzhOS#662` 的自动同步 PR 已通过 Sentinel，但 `trailer-check` 失败。根因是 Caller Sync 创建的 commit message 只有标题，缺少目标仓治理门禁要求的 trailers。

## 影响

- 后续 Caller Sync live 生成的同步 commit 会携带治理 trailers。
- 不改变 canonical caller workflow 内容本身。
- 不修改 token、secret、权限模型或 merge 策略。

## 护栏

- 本 PR 只修改 Caller Sync workflow 与对应形状测试。
- 不合并目标仓 caller sync PR。
- 不读取、不输出任何 secret 或 token 值。
- `actionlint .github/workflows/caller-sync.yml` 仍会报告既有 shellcheck/style 项，本 PR 未扩大处理该历史债务。

## 验证命令

```bash
bash tests/test-caller-sync-workflow.sh
bash tests/test-self-test-workflow.sh
bash tests/test-caller-token-write-probe-workflow.sh
git diff --check
```

验证结果：以上四项均通过。
